### PR TITLE
fix(env varaible value): use internal Postgres port (5432) for servic…

### DIFF
--- a/.env
+++ b/.env
@@ -5,7 +5,7 @@ DB_PASSWORD="metadata1337_"
 DB_NAME="cf_token_metadata_registry"
 DB_HOST='db'
 DB_PORT='5432'
-DB_URL=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+DB_URL=jdbc:postgresql://${DB_HOST}:5432/${DB_NAME}
 
 # API Details
 API_EXPOSED_PORT='8080'


### PR DESCRIPTION


Updated DB_URL to use internal Docker network port 5432 instead of external mapped port. Ensures services connect correctly within Docker network and prevents connection errors.