### PR TITLE
refactor: replace shell git commands with JGit library

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -88,6 +88,10 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
@@ -34,17 +34,17 @@ import java.util.Optional;
 public class GitService {
 
     @Value("${git.organization:cardano-foundation}")
-    private String organization;
+    String organization;
     @Value("${git.projectName:cardano-token-registry}")
-    private String projectName;
+    String projectName;
     @Value("${git.mappingsFolder:mappings}")
-    private String mappingsFolderName;
+    String mappingsFolderName;
     @Value("${git.tmp.folder:/tmp}")
-    private String gitTempFolder;
+    String gitTempFolder;
     @Value("${git.forceClone:false}")
-    private boolean forceClone;
+    boolean forceClone;
 
-    private Git git;
+    Git git;
 
     @PostConstruct
     void validateConfig() {

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
@@ -1,22 +1,31 @@
 package org.cardanofoundation.tokenmetadata.registry.service;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.cardanofoundation.tokenmetadata.registry.model.MappingUpdateDetails;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.BranchConfig;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.diff.DiffEntry;
+import org.eclipse.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.AbstractTreeIterator;
+import org.eclipse.jgit.treewalk.CanonicalTreeParser;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileSystemUtils;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
-
-import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
 @Service
 @Slf4j
@@ -33,11 +42,20 @@ public class GitService {
     @Value("${git.forceClone:false}")
     private boolean forceClone;
 
+    private Git git;
+
     @PostConstruct
     void validateConfig() {
         if (gitTempFolder == null || gitTempFolder.isBlank()) {
             log.warn("git.tmp.folder is blank, defaulting to system temp directory");
             gitTempFolder = System.getProperty("java.io.tmpdir");
+        }
+    }
+
+    @PreDestroy
+    void cleanup() {
+        if (git != null) {
+            git.close();
         }
     }
 
@@ -47,11 +65,12 @@ public class GitService {
         boolean repoReady;
         if (gitFolder.exists() && (forceClone || !isGitRepo())) {
             log.info("exists and either force clone or not a git repo");
+            cleanup();
             FileSystemUtils.deleteRecursively(gitFolder);
             repoReady = cloneRepo();
         } else if (gitFolder.exists() && isGitRepo()) {
             log.info("exists and is git repo");
-            repoReady = pullRebaseRepo();
+            repoReady = openExistingRepo() && pullRebaseRepo();
         } else {
             repoReady = cloneRepo();
         }
@@ -63,16 +82,28 @@ public class GitService {
         }
     }
 
+    private boolean openExistingRepo() {
+        try {
+            if (git != null) {
+                git.close();
+            }
+            git = Git.open(getGitFolder());
+            return true;
+        } catch (IOException e) {
+            log.warn("Failed to open existing git repository", e);
+            return false;
+        }
+    }
+
     private boolean cloneRepo() {
         try {
             var url = String.format("https://github.com/%s/%s.git", organization, projectName);
-            var process = new ProcessBuilder()
-                    .directory(getGitFolder().getParentFile())
-                    .command("git", "clone", url)
-                    .start();
-            var exitCode = process.waitFor();
-            return exitCode == 0;
-        } catch (Exception e) {
+            git = Git.cloneRepository()
+                    .setURI(url)
+                    .setDirectory(getGitFolder())
+                    .call();
+            return true;
+        } catch (GitAPIException e) {
             log.warn(String.format("It was not possible to clone the %s project", projectName), e);
             return false;
         }
@@ -80,41 +111,17 @@ public class GitService {
 
     private boolean pullRebaseRepo() {
         try {
-            if (!hasRemote()) {
-                log.info("Local git repo has no remote configured, using as-is");
-                return true;
-            }
-            var process = new ProcessBuilder()
-                    .directory(getGitFolder())
-                    .command("git", "pull", "--rebase")
-                    .start();
-
-            var exitCode = process.waitFor();
-            return exitCode == 0;
-        } catch (Exception e) {
+            git.pull()
+                    .setRebase(BranchConfig.BranchRebaseMode.REBASE)
+                    .call();
+            return true;
+        } catch (GitAPIException e) {
             log.warn("it was not possible to update repo. cloning from scratch", e);
             return false;
         }
     }
 
-    private boolean hasRemote() {
-        try {
-            var process = new ProcessBuilder()
-                    .directory(getGitFolder())
-                    .command("git", "remote")
-                    .start();
-            var exitCode = process.waitFor();
-            if (exitCode == 0) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                return reader.readLine() != null;
-            }
-        } catch (Exception e) {
-            log.warn("Failed to check git remotes", e);
-        }
-        return false;
-    }
-
-    private boolean isGitRepo() {
+private boolean isGitRepo() {
         return getGitFolder().toPath().resolve(".git").toFile().exists();
     }
 
@@ -127,70 +134,105 @@ public class GitService {
     }
 
     public Optional<MappingUpdateDetails> getMappingDetails(File mappingFile) {
-        try {
-            var process = new ProcessBuilder()
-                    .directory(getMappingsFolder().toFile())
-                    .command("git", "log", "-n", "1", "--date-order", "--no-merges",
-                            "--pretty=format:%aE#-#%aI", mappingFile.getName())
-                    .start();
-
-            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-            String output = bufferedReader.readLine();
-
-            if (output == null || !output.contains("#-#")) {
-                return Optional.empty();
-            }
-
-            var parts = output.split("#-#");
-
-            return Optional.of(new MappingUpdateDetails(parts[0], LocalDateTime.parse(parts[1], ISO_OFFSET_DATE_TIME)));
-
-        } catch (IOException e) {
-            log.warn(String.format("it was not possible to determine updatedBy and updatedAt for mapping file: %s", mappingFile.getName()), e);
+        if (git == null) {
+            log.warn("Git repository not initialized");
             return Optional.empty();
         }
+        try {
+            Repository repository = git.getRepository();
+            String relativePath = mappingsFolderName + "/" + mappingFile.getName();
 
+            Iterable<RevCommit> commits = git.log()
+                    .addPath(relativePath)
+                    .setMaxCount(10)
+                    .call();
+
+            for (RevCommit commit : commits) {
+                if (commit.getParentCount() <= 1) {
+                    PersonIdent author = commit.getAuthorIdent();
+                    String email = author.getEmailAddress();
+                    LocalDateTime updatedAt = LocalDateTime.ofInstant(
+                            author.getWhenAsInstant(), ZoneOffset.UTC);
+                    return Optional.of(new MappingUpdateDetails(email, updatedAt));
+                }
+            }
+
+            return Optional.empty();
+        } catch (GitAPIException e) {
+            log.warn(String.format("it was not possible to determine updatedBy and updatedAt for mapping file: %s",
+                    mappingFile.getName()), e);
+            return Optional.empty();
+        }
     }
 
     public Optional<String> getHeadCommitHash() {
+        if (git == null) {
+            log.warn("Git repository not initialized");
+            return Optional.empty();
+        }
         try {
-            var process = new ProcessBuilder()
-                    .directory(getGitFolder())
-                    .command("git", "rev-parse", "HEAD")
-                    .start();
-            var exitCode = process.waitFor();
-            if (exitCode == 0) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                String hash = reader.readLine();
-                if (hash != null && hash.trim().length() == 40) {
-                    return Optional.of(hash.trim());
-                }
+            Repository repository = git.getRepository();
+            ObjectId head = repository.resolve("HEAD");
+            if (head != null) {
+                return Optional.of(head.name());
             }
-        } catch (Exception e) {
+        } catch (IOException e) {
             log.warn("Failed to get HEAD commit hash", e);
         }
         return Optional.empty();
     }
 
     public List<Path> getChangedFiles(String fromHash, String toHash) {
+        if (git == null) {
+            log.warn("Git repository not initialized");
+            return List.of();
+        }
         try {
-            var process = new ProcessBuilder()
-                    .directory(getGitFolder())
-                    .command("git", "diff", fromHash + ".." + toHash, "--name-only", "--diff-filter=AM")
-                    .start();
-            var exitCode = process.waitFor();
-            if (exitCode == 0) {
-                BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
-                return reader.lines()
-                        .filter(line -> line.startsWith(mappingsFolderName + "/"))
-                        .filter(line -> line.endsWith(".json"))
-                        .map(line -> getGitFolder().toPath().resolve(line))
-                        .toList();
+            Repository repository = git.getRepository();
+
+            ObjectId oldId = repository.resolve(fromHash);
+            ObjectId newId = repository.resolve(toHash);
+
+            if (oldId == null || newId == null) {
+                log.warn("Could not resolve commit hashes: {} -> {}", fromHash, toHash);
+                return List.of();
             }
+
+            AbstractTreeIterator oldTree = prepareTreeParser(repository, oldId);
+            AbstractTreeIterator newTree = prepareTreeParser(repository, newId);
+
+            List<DiffEntry> diffs = git.diff()
+                    .setOldTree(oldTree)
+                    .setNewTree(newTree)
+                    .call();
+
+            return diffs.stream()
+                    .filter(d -> d.getChangeType() == DiffEntry.ChangeType.ADD
+                            || d.getChangeType() == DiffEntry.ChangeType.MODIFY)
+                    .map(DiffEntry::getNewPath)
+                    .filter(path -> path.startsWith(mappingsFolderName + "/"))
+                    .filter(path -> path.endsWith(".json"))
+                    .map(path -> getGitFolder().toPath().resolve(path))
+                    .toList();
         } catch (Exception e) {
             log.warn(String.format("Failed to get changed files between %s and %s", fromHash, toHash), e);
         }
         return List.of();
+    }
+
+    private AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId) throws IOException {
+        try (RevWalk walk = new RevWalk(repository)) {
+            var commit = walk.parseCommit(objectId);
+            var tree = walk.parseTree(commit.getTree().getId());
+
+            var treeParser = new CanonicalTreeParser();
+            try (var reader = repository.newObjectReader()) {
+                treeParser.reset(reader, tree.getId());
+            }
+
+            walk.dispose();
+            return treeParser;
+        }
     }
 
 }

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
@@ -13,8 +13,10 @@ import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.revwalk.filter.RevFilter;
 import org.eclipse.jgit.treewalk.AbstractTreeIterator;
 import org.eclipse.jgit.treewalk.CanonicalTreeParser;
+import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.FileSystemUtils;
@@ -56,6 +58,7 @@ public class GitService {
     void cleanup() {
         if (git != null) {
             git.close();
+            git = null;
         }
     }
 
@@ -84,9 +87,7 @@ public class GitService {
 
     private boolean openExistingRepo() {
         try {
-            if (git != null) {
-                git.close();
-            }
+            cleanup();
             git = Git.open(getGitFolder());
             return true;
         } catch (IOException e) {
@@ -104,7 +105,7 @@ public class GitService {
                     .call();
             return true;
         } catch (GitAPIException e) {
-            log.warn(String.format("It was not possible to clone the %s project", projectName), e);
+            log.warn("It was not possible to clone the {} project", projectName, e);
             return false;
         }
     }
@@ -126,7 +127,7 @@ private boolean isGitRepo() {
     }
 
     private File getGitFolder() {
-        return new File(String.format("%s/%s", gitTempFolder, projectName));
+        return Path.of(gitTempFolder).resolve(projectName).toFile();
     }
 
     private Path getMappingsFolder() {
@@ -139,28 +140,26 @@ private boolean isGitRepo() {
             return Optional.empty();
         }
         try {
-            Repository repository = git.getRepository();
             String relativePath = mappingsFolderName + "/" + mappingFile.getName();
 
             Iterable<RevCommit> commits = git.log()
                     .addPath(relativePath)
-                    .setMaxCount(10)
+                    .setRevFilter(RevFilter.NO_MERGES)
+                    .setMaxCount(1)
                     .call();
 
             for (RevCommit commit : commits) {
-                if (commit.getParentCount() <= 1) {
-                    PersonIdent author = commit.getAuthorIdent();
-                    String email = author.getEmailAddress();
-                    LocalDateTime updatedAt = LocalDateTime.ofInstant(
-                            author.getWhenAsInstant(), ZoneOffset.UTC);
-                    return Optional.of(new MappingUpdateDetails(email, updatedAt));
-                }
+                PersonIdent author = commit.getAuthorIdent();
+                String email = author.getEmailAddress();
+                LocalDateTime updatedAt = LocalDateTime.ofInstant(
+                        author.getWhenAsInstant(), ZoneOffset.UTC);
+                return Optional.of(new MappingUpdateDetails(email, updatedAt));
             }
 
             return Optional.empty();
         } catch (GitAPIException e) {
-            log.warn(String.format("it was not possible to determine updatedBy and updatedAt for mapping file: %s",
-                    mappingFile.getName()), e);
+            log.warn("it was not possible to determine updatedBy and updatedAt for mapping file: {}",
+                    mappingFile.getName(), e);
             return Optional.empty();
         }
     }
@@ -204,18 +203,19 @@ private boolean isGitRepo() {
             List<DiffEntry> diffs = git.diff()
                     .setOldTree(oldTree)
                     .setNewTree(newTree)
+                    .setPathFilter(PathFilter.create(mappingsFolderName))
                     .call();
 
+            Path repoRoot = getGitFolder().toPath();
             return diffs.stream()
                     .filter(d -> d.getChangeType() == DiffEntry.ChangeType.ADD
                             || d.getChangeType() == DiffEntry.ChangeType.MODIFY)
                     .map(DiffEntry::getNewPath)
-                    .filter(path -> path.startsWith(mappingsFolderName + "/"))
                     .filter(path -> path.endsWith(".json"))
-                    .map(path -> getGitFolder().toPath().resolve(path))
+                    .map(repoRoot::resolve)
                     .toList();
         } catch (Exception e) {
-            log.warn(String.format("Failed to get changed files between %s and %s", fromHash, toHash), e);
+            log.warn("Failed to get changed files between {} and {}", fromHash, toHash, e);
         }
         return List.of();
     }
@@ -223,14 +223,10 @@ private boolean isGitRepo() {
     private AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId) throws IOException {
         try (RevWalk walk = new RevWalk(repository)) {
             var commit = walk.parseCommit(objectId);
-            var tree = walk.parseTree(commit.getTree().getId());
-
             var treeParser = new CanonicalTreeParser();
             try (var reader = repository.newObjectReader()) {
-                treeParser.reset(reader, tree.getId());
+                treeParser.reset(reader, commit.getTree().getId());
             }
-
-            walk.dispose();
             return treeParser;
         }
     }

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
@@ -112,6 +112,11 @@ public class GitService {
 
     private boolean pullRebaseRepo() {
         try {
+            var remotes = git.remoteList().call();
+            if (remotes.isEmpty()) {
+                log.info("No remote configured, skipping pull");
+                return true;
+            }
             git.pull()
                     .setRebase(BranchConfig.BranchRebaseMode.REBASE)
                     .call();

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
@@ -1,0 +1,423 @@
+package org.cardanofoundation.tokenmetadata.registry.service;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.PersonIdent;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitServiceTest {
+
+    private GitService gitService;
+
+    @TempDir
+    Path tempDir;
+
+    private Git testRepo;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        gitService = new GitService();
+        setField("organization", "test-org");
+        setField("projectName", "test-repo");
+        setField("mappingsFolderName", "mappings");
+        setField("gitTempFolder", tempDir.toString());
+        setField("forceClone", false);
+    }
+
+    private void setField(String name, Object value) throws Exception {
+        Field field = GitService.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(gitService, value);
+    }
+
+    private void setGit(Git git) throws Exception {
+        Field field = GitService.class.getDeclaredField("git");
+        field.setAccessible(true);
+        field.set(gitService, git);
+    }
+
+    private Git initRepoWithMappings() throws GitAPIException, IOException {
+        Path repoDir = tempDir.resolve("test-repo");
+        Files.createDirectories(repoDir.resolve("mappings"));
+        Git git = Git.init().setDirectory(repoDir.toFile()).call();
+
+        // initial commit so HEAD exists
+        Files.writeString(repoDir.resolve("README.md"), "init");
+        git.add().addFilepattern("README.md").call();
+        git.commit().setMessage("initial commit")
+                .setAuthor(new PersonIdent("Init", "init@test.com"))
+                .call();
+
+        return git;
+    }
+
+    private RevCommit addMappingFile(Git git, String fileName, String content, String email) throws Exception {
+        Path mappingsDir = git.getRepository().getWorkTree().toPath().resolve("mappings");
+        Files.createDirectories(mappingsDir);
+        Files.writeString(mappingsDir.resolve(fileName), content);
+        git.add().addFilepattern("mappings/" + fileName).call();
+        return git.commit().setMessage("add " + fileName)
+                .setAuthor(new PersonIdent("Test Author", email))
+                .call();
+    }
+
+    @Nested
+    class GetHeadCommitHash {
+
+        @Test
+        void returnsHashFromRepo() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+
+            var result = gitService.getHeadCommitHash();
+
+            assertThat(result).isPresent();
+            assertThat(result.get()).hasSize(40).matches("[0-9a-f]+");
+        }
+
+        @Test
+        void returnsEmptyWhenGitIsNull() {
+            var result = gitService.getHeadCommitHash();
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void matchesActualHeadCommit() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String expectedHash = testRepo.getRepository().resolve("HEAD").name();
+
+            var result = gitService.getHeadCommitHash();
+
+            assertThat(result).hasValue(expectedHash);
+        }
+
+        @Test
+        void updatesAfterNewCommit() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String firstHash = gitService.getHeadCommitHash().orElseThrow();
+
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String secondHash = gitService.getHeadCommitHash().orElseThrow();
+
+            assertThat(secondHash).isNotEqualTo(firstHash);
+        }
+    }
+
+    @Nested
+    class GetMappingDetails {
+
+        @Test
+        void returnsAuthorEmailAndDate() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String email = "author@cardano.org";
+            RevCommit commit = addMappingFile(testRepo, "token1.json", "{\"subject\":\"abc\"}", email);
+
+            var result = gitService.getMappingDetails(new File("token1.json"));
+
+            assertThat(result).isPresent();
+            assertThat(result.get().updatedBy()).isEqualTo(email);
+            LocalDateTime expectedTime = LocalDateTime.ofInstant(
+                    commit.getAuthorIdent().getWhenAsInstant(), ZoneOffset.UTC);
+            assertThat(result.get().updatedAt()).isEqualTo(expectedTime);
+        }
+
+        @Test
+        void returnsEmptyForUnknownFile() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+
+            var result = gitService.getMappingDetails(new File("nonexistent.json"));
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void returnsLatestNonMergeCommit() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+
+            addMappingFile(testRepo, "token1.json", "{\"v\":1}", "first@test.com");
+            RevCommit latest = addMappingFile(testRepo, "token1.json", "{\"v\":2}", "latest@test.com");
+
+            var result = gitService.getMappingDetails(new File("token1.json"));
+
+            assertThat(result).isPresent();
+            assertThat(result.get().updatedBy()).isEqualTo("latest@test.com");
+        }
+
+        @Test
+        void returnsEmptyWhenGitIsNull() {
+            var result = gitService.getMappingDetails(new File("token1.json"));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetChangedFiles {
+
+        @Test
+        void returnsAddedJsonFilesInMappingsFolder() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).hasSize(1);
+            assertThat(changed.get(0).getFileName().toString()).isEqualTo("token1.json");
+        }
+
+        @Test
+        void returnsModifiedFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            addMappingFile(testRepo, "token1.json", "{\"v\":1}", "dev@test.com");
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            addMappingFile(testRepo, "token1.json", "{\"v\":2}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).hasSize(1);
+            assertThat(changed.get(0).getFileName().toString()).isEqualTo("token1.json");
+        }
+
+        @Test
+        void filtersOutNonJsonFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            addMappingFile(testRepo, "readme.txt", "text", "dev@test.com");
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).hasSize(1);
+            assertThat(changed.get(0).getFileName().toString()).isEqualTo("token1.json");
+        }
+
+        @Test
+        void filtersOutFilesOutsideMappingsFolder() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            // add file outside mappings
+            Path repoDir = testRepo.getRepository().getWorkTree().toPath();
+            Files.writeString(repoDir.resolve("other.json"), "{}");
+            testRepo.add().addFilepattern("other.json").call();
+            testRepo.commit().setMessage("add other.json")
+                    .setAuthor(new PersonIdent("Dev", "dev@test.com"))
+                    .call();
+
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).hasSize(1);
+            assertThat(changed.get(0).getFileName().toString()).isEqualTo("token1.json");
+        }
+
+        @Test
+        void filtersOutDeletedFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            // delete token1.json
+            Path repoDir = testRepo.getRepository().getWorkTree().toPath();
+            Files.delete(repoDir.resolve("mappings/token1.json"));
+            testRepo.rm().addFilepattern("mappings/token1.json").call();
+            testRepo.commit().setMessage("delete token1")
+                    .setAuthor(new PersonIdent("Dev", "dev@test.com"))
+                    .call();
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForSameHash() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String hash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(hash, hash);
+
+            assertThat(changed).isEmpty();
+        }
+
+        @Test
+        void returnsEmptyForInvalidHashes() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+
+            List<Path> changed = gitService.getChangedFiles(
+                    "0000000000000000000000000000000000000000",
+                    "1111111111111111111111111111111111111111");
+
+            assertThat(changed).isEmpty();
+        }
+
+        @Test
+        void returnsMultipleChangedFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+            addMappingFile(testRepo, "token3.json", "{}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+
+            assertThat(changed).hasSize(3)
+                    .extracting(p -> p.getFileName().toString())
+                    .containsExactlyInAnyOrder("token1.json", "token2.json", "token3.json");
+        }
+    }
+
+    @Nested
+    class ValidateConfig {
+
+        @Test
+        void defaultsToSystemTempWhenBlank() throws Exception {
+            setField("gitTempFolder", "");
+
+            gitService.validateConfig();
+
+            Field field = GitService.class.getDeclaredField("gitTempFolder");
+            field.setAccessible(true);
+            assertThat(field.get(gitService)).isEqualTo(System.getProperty("java.io.tmpdir"));
+        }
+
+        @Test
+        void keepsValueWhenNotBlank() throws Exception {
+            String customPath = "/custom/path";
+            setField("gitTempFolder", customPath);
+
+            gitService.validateConfig();
+
+            Field field = GitService.class.getDeclaredField("gitTempFolder");
+            field.setAccessible(true);
+            assertThat(field.get(gitService)).isEqualTo(customPath);
+        }
+    }
+
+    @Nested
+    class Cleanup {
+
+        @Test
+        void closesGitWhenNotNull() throws Exception {
+            testRepo = initRepoWithMappings();
+            setGit(testRepo);
+
+            gitService.cleanup();
+
+            // verify no exception thrown and git is still set (but closed)
+            Field field = GitService.class.getDeclaredField("git");
+            field.setAccessible(true);
+            assertThat(field.get(gitService)).isNotNull();
+        }
+
+        @Test
+        void handlesNullGitGracefully() {
+            // should not throw
+            gitService.cleanup();
+        }
+    }
+
+    @Nested
+    class CloneCardanoTokenRegistryGitRepository {
+
+        @Test
+        void pullsWhenRepoAlreadyExists() throws Exception {
+            // set up a local "remote" and clone from it
+            Path remoteDir = tempDir.resolve("remote-repo");
+            Git remoteGit = Git.init().setBare(true).setDirectory(remoteDir.toFile()).call();
+
+            // create a non-bare repo, add content, push to remote
+            Path seedDir = tempDir.resolve("seed");
+            Git seedGit = Git.init().setDirectory(seedDir.toFile()).call();
+            Files.createDirectories(seedDir.resolve("mappings"));
+            Files.writeString(seedDir.resolve("mappings/token.json"), "{}");
+            seedGit.add().addFilepattern(".").call();
+            seedGit.commit().setMessage("init")
+                    .setAuthor(new PersonIdent("Seed", "seed@test.com"))
+                    .call();
+            seedGit.push().setRemote(remoteDir.toUri().toString()).call();
+            seedGit.close();
+
+            // clone from local remote into the expected directory
+            Path repoDir = tempDir.resolve("test-repo");
+            Git clonedGit = Git.cloneRepository()
+                    .setURI(remoteDir.toUri().toString())
+                    .setDirectory(repoDir.toFile())
+                    .call();
+            clonedGit.close();
+
+            var result = gitService.cloneCardanoTokenRegistryGitRepository();
+
+            assertThat(result).isPresent();
+            assertThat(result.get().toFile()).exists();
+            assertThat(result.get().getFileName().toString()).isEqualTo("mappings");
+        }
+
+        @Test
+        void returnsEmptyWhenCloneFails() {
+            // organization/project point to non-existent remote, clone will fail
+            var result = gitService.cloneCardanoTokenRegistryGitRepository();
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        void forceCloneDeletesExistingNonGitDir() throws Exception {
+            setField("forceClone", true);
+
+            // create a non-git directory at the expected path
+            Path repoDir = tempDir.resolve("test-repo");
+            Files.createDirectories(repoDir.resolve("mappings"));
+            Files.writeString(repoDir.resolve("some-file.txt"), "stale");
+
+            // clone will fail (bad remote), but the directory should have been deleted
+            var result = gitService.cloneCardanoTokenRegistryGitRepository();
+
+            assertThat(result).isEmpty();
+            // the stale file should be gone (directory was deleted before clone attempt)
+            assertThat(repoDir.resolve("some-file.txt")).doesNotExist();
+        }
+    }
+}

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -33,11 +32,11 @@ class GitServiceTest {
     @BeforeEach
     void setUp() {
         gitService = new GitService();
-        ReflectionTestUtils.setField(gitService, "organization", "test-org");
-        ReflectionTestUtils.setField(gitService, "projectName", "test-repo");
-        ReflectionTestUtils.setField(gitService, "mappingsFolderName", "mappings");
-        ReflectionTestUtils.setField(gitService, "gitTempFolder", tempDir.toString());
-        ReflectionTestUtils.setField(gitService, "forceClone", false);
+        gitService.organization = "test-org";
+        gitService.projectName = "test-repo";
+        gitService.mappingsFolderName = "mappings";
+        gitService.gitTempFolder = tempDir.toString();
+        gitService.forceClone = false;
     }
 
     @AfterEach
@@ -79,7 +78,7 @@ class GitServiceTest {
         @Test
         void returnsHashFromRepo() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
 
             var result = gitService.getHeadCommitHash();
 
@@ -97,7 +96,7 @@ class GitServiceTest {
         @Test
         void matchesActualHeadCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String expectedHash = testRepo.getRepository().resolve("HEAD").name();
 
             var result = gitService.getHeadCommitHash();
@@ -108,7 +107,7 @@ class GitServiceTest {
         @Test
         void updatesAfterNewCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String firstHash = gitService.getHeadCommitHash().orElseThrow();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -124,7 +123,7 @@ class GitServiceTest {
         @Test
         void returnsAuthorEmailAndDate() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String email = "author@cardano.org";
             RevCommit commit = addMappingFile(testRepo, "token1.json", "{\"subject\":\"abc\"}", email);
 
@@ -140,7 +139,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForUnknownFile() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
 
             var result = gitService.getMappingDetails(new File("nonexistent.json"));
 
@@ -150,7 +149,7 @@ class GitServiceTest {
         @Test
         void returnsLatestNonMergeCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
 
             addMappingFile(testRepo, "token1.json", "{\"v\":1}", "first@test.com");
             addMappingFile(testRepo, "token1.json", "{\"v\":2}", "latest@test.com");
@@ -175,7 +174,7 @@ class GitServiceTest {
         @Test
         void returnsAddedJsonFilesInMappingsFolder() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -190,7 +189,7 @@ class GitServiceTest {
         @Test
         void returnsModifiedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             addMappingFile(testRepo, "token1.json", "{\"v\":1}", "dev@test.com");
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
@@ -206,7 +205,7 @@ class GitServiceTest {
         @Test
         void filtersOutNonJsonFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "readme.txt", "text", "dev@test.com");
@@ -222,7 +221,7 @@ class GitServiceTest {
         @Test
         void filtersOutFilesOutsideMappingsFolder() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             Path repoDir = testRepo.getRepository().getWorkTree().toPath();
@@ -244,7 +243,7 @@ class GitServiceTest {
         @Test
         void filtersOutDeletedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
@@ -265,7 +264,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForSameHash() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String hash = testRepo.getRepository().resolve("HEAD").name();
 
             List<Path> changed = gitService.getChangedFiles(hash, hash);
@@ -276,7 +275,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForInvalidHashes() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
 
             List<Path> changed = gitService.getChangedFiles(
                     "0000000000000000000000000000000000000000",
@@ -288,7 +287,7 @@ class GitServiceTest {
         @Test
         void returnsMultipleChangedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -309,23 +308,21 @@ class GitServiceTest {
 
         @Test
         void defaultsToSystemTempWhenBlank() {
-            ReflectionTestUtils.setField(gitService, "gitTempFolder", "");
+            gitService.gitTempFolder = "";
 
             gitService.validateConfig();
 
-            assertThat(ReflectionTestUtils.getField(gitService, "gitTempFolder"))
-                    .isEqualTo(System.getProperty("java.io.tmpdir"));
+            assertThat(gitService.gitTempFolder).isEqualTo(System.getProperty("java.io.tmpdir"));
         }
 
         @Test
         void keepsValueWhenNotBlank() {
             String customPath = "/custom/path";
-            ReflectionTestUtils.setField(gitService, "gitTempFolder", customPath);
+            gitService.gitTempFolder = customPath;
 
             gitService.validateConfig();
 
-            assertThat(ReflectionTestUtils.getField(gitService, "gitTempFolder"))
-                    .isEqualTo(customPath);
+            assertThat(gitService.gitTempFolder).isEqualTo(customPath);
         }
     }
 
@@ -335,11 +332,11 @@ class GitServiceTest {
         @Test
         void closesAndNullsGit() throws Exception {
             testRepo = initRepoWithMappings();
-            ReflectionTestUtils.setField(gitService, "git", testRepo);
+            gitService.git = testRepo;
 
             gitService.cleanup();
 
-            assertThat(ReflectionTestUtils.getField(gitService, "git")).isNull();
+            assertThat(gitService.git).isNull();
             // prevent double-close in tearDown
             testRepo = null;
         }
@@ -373,7 +370,6 @@ class GitServiceTest {
                         .setURI(remoteDir.toUri().toString())
                         .setDirectory(repoDir.toFile())
                         .call()) {
-                    // cloned, now close so GitService can open it
                 }
             }
 
@@ -393,7 +389,7 @@ class GitServiceTest {
 
         @Test
         void forceCloneDeletesExistingNonGitDir() throws Exception {
-            ReflectionTestUtils.setField(gitService, "forceClone", true);
+            gitService.forceClone = true;
 
             Path repoDir = tempDir.resolve("test-repo");
             Files.createDirectories(repoDir.resolve("mappings"));

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
@@ -4,14 +4,15 @@ import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
@@ -30,25 +31,22 @@ class GitServiceTest {
     private Git testRepo;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
         gitService = new GitService();
-        setField("organization", "test-org");
-        setField("projectName", "test-repo");
-        setField("mappingsFolderName", "mappings");
-        setField("gitTempFolder", tempDir.toString());
-        setField("forceClone", false);
+        ReflectionTestUtils.setField(gitService, "organization", "test-org");
+        ReflectionTestUtils.setField(gitService, "projectName", "test-repo");
+        ReflectionTestUtils.setField(gitService, "mappingsFolderName", "mappings");
+        ReflectionTestUtils.setField(gitService, "gitTempFolder", tempDir.toString());
+        ReflectionTestUtils.setField(gitService, "forceClone", false);
     }
 
-    private void setField(String name, Object value) throws Exception {
-        Field field = GitService.class.getDeclaredField(name);
-        field.setAccessible(true);
-        field.set(gitService, value);
-    }
-
-    private void setGit(Git git) throws Exception {
-        Field field = GitService.class.getDeclaredField("git");
-        field.setAccessible(true);
-        field.set(gitService, git);
+    @AfterEach
+    void tearDown() {
+        if (testRepo != null) {
+            testRepo.close();
+            testRepo = null;
+        }
+        gitService.cleanup();
     }
 
     private Git initRepoWithMappings() throws GitAPIException, IOException {
@@ -56,7 +54,6 @@ class GitServiceTest {
         Files.createDirectories(repoDir.resolve("mappings"));
         Git git = Git.init().setDirectory(repoDir.toFile()).call();
 
-        // initial commit so HEAD exists
         Files.writeString(repoDir.resolve("README.md"), "init");
         git.add().addFilepattern("README.md").call();
         git.commit().setMessage("initial commit")
@@ -82,7 +79,7 @@ class GitServiceTest {
         @Test
         void returnsHashFromRepo() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
 
             var result = gitService.getHeadCommitHash();
 
@@ -100,7 +97,7 @@ class GitServiceTest {
         @Test
         void matchesActualHeadCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String expectedHash = testRepo.getRepository().resolve("HEAD").name();
 
             var result = gitService.getHeadCommitHash();
@@ -111,7 +108,7 @@ class GitServiceTest {
         @Test
         void updatesAfterNewCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String firstHash = gitService.getHeadCommitHash().orElseThrow();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -127,7 +124,7 @@ class GitServiceTest {
         @Test
         void returnsAuthorEmailAndDate() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String email = "author@cardano.org";
             RevCommit commit = addMappingFile(testRepo, "token1.json", "{\"subject\":\"abc\"}", email);
 
@@ -143,7 +140,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForUnknownFile() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
 
             var result = gitService.getMappingDetails(new File("nonexistent.json"));
 
@@ -153,10 +150,10 @@ class GitServiceTest {
         @Test
         void returnsLatestNonMergeCommit() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
 
             addMappingFile(testRepo, "token1.json", "{\"v\":1}", "first@test.com");
-            RevCommit latest = addMappingFile(testRepo, "token1.json", "{\"v\":2}", "latest@test.com");
+            addMappingFile(testRepo, "token1.json", "{\"v\":2}", "latest@test.com");
 
             var result = gitService.getMappingDetails(new File("token1.json"));
 
@@ -178,7 +175,7 @@ class GitServiceTest {
         @Test
         void returnsAddedJsonFilesInMappingsFolder() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -193,7 +190,7 @@ class GitServiceTest {
         @Test
         void returnsModifiedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             addMappingFile(testRepo, "token1.json", "{\"v\":1}", "dev@test.com");
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
@@ -209,7 +206,7 @@ class GitServiceTest {
         @Test
         void filtersOutNonJsonFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "readme.txt", "text", "dev@test.com");
@@ -225,10 +222,9 @@ class GitServiceTest {
         @Test
         void filtersOutFilesOutsideMappingsFolder() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
-            // add file outside mappings
             Path repoDir = testRepo.getRepository().getWorkTree().toPath();
             Files.writeString(repoDir.resolve("other.json"), "{}");
             testRepo.add().addFilepattern("other.json").call();
@@ -248,12 +244,11 @@ class GitServiceTest {
         @Test
         void filtersOutDeletedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
-            // delete token1.json
             Path repoDir = testRepo.getRepository().getWorkTree().toPath();
             Files.delete(repoDir.resolve("mappings/token1.json"));
             testRepo.rm().addFilepattern("mappings/token1.json").call();
@@ -270,7 +265,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForSameHash() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String hash = testRepo.getRepository().resolve("HEAD").name();
 
             List<Path> changed = gitService.getChangedFiles(hash, hash);
@@ -281,7 +276,7 @@ class GitServiceTest {
         @Test
         void returnsEmptyForInvalidHashes() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
 
             List<Path> changed = gitService.getChangedFiles(
                     "0000000000000000000000000000000000000000",
@@ -293,7 +288,7 @@ class GitServiceTest {
         @Test
         void returnsMultipleChangedFiles() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
@@ -313,48 +308,44 @@ class GitServiceTest {
     class ValidateConfig {
 
         @Test
-        void defaultsToSystemTempWhenBlank() throws Exception {
-            setField("gitTempFolder", "");
+        void defaultsToSystemTempWhenBlank() {
+            ReflectionTestUtils.setField(gitService, "gitTempFolder", "");
 
             gitService.validateConfig();
 
-            Field field = GitService.class.getDeclaredField("gitTempFolder");
-            field.setAccessible(true);
-            assertThat(field.get(gitService)).isEqualTo(System.getProperty("java.io.tmpdir"));
+            assertThat(ReflectionTestUtils.getField(gitService, "gitTempFolder"))
+                    .isEqualTo(System.getProperty("java.io.tmpdir"));
         }
 
         @Test
-        void keepsValueWhenNotBlank() throws Exception {
+        void keepsValueWhenNotBlank() {
             String customPath = "/custom/path";
-            setField("gitTempFolder", customPath);
+            ReflectionTestUtils.setField(gitService, "gitTempFolder", customPath);
 
             gitService.validateConfig();
 
-            Field field = GitService.class.getDeclaredField("gitTempFolder");
-            field.setAccessible(true);
-            assertThat(field.get(gitService)).isEqualTo(customPath);
+            assertThat(ReflectionTestUtils.getField(gitService, "gitTempFolder"))
+                    .isEqualTo(customPath);
         }
     }
 
     @Nested
-    class Cleanup {
+    class CleanupTest {
 
         @Test
-        void closesGitWhenNotNull() throws Exception {
+        void closesAndNullsGit() throws Exception {
             testRepo = initRepoWithMappings();
-            setGit(testRepo);
+            ReflectionTestUtils.setField(gitService, "git", testRepo);
 
             gitService.cleanup();
 
-            // verify no exception thrown and git is still set (but closed)
-            Field field = GitService.class.getDeclaredField("git");
-            field.setAccessible(true);
-            assertThat(field.get(gitService)).isNotNull();
+            assertThat(ReflectionTestUtils.getField(gitService, "git")).isNull();
+            // prevent double-close in tearDown
+            testRepo = null;
         }
 
         @Test
         void handlesNullGitGracefully() {
-            // should not throw
             gitService.cleanup();
         }
     }
@@ -364,29 +355,27 @@ class GitServiceTest {
 
         @Test
         void pullsWhenRepoAlreadyExists() throws Exception {
-            // set up a local "remote" and clone from it
             Path remoteDir = tempDir.resolve("remote-repo");
-            Git remoteGit = Git.init().setBare(true).setDirectory(remoteDir.toFile()).call();
+            try (Git remoteGit = Git.init().setBare(true).setDirectory(remoteDir.toFile()).call()) {
+                Path seedDir = tempDir.resolve("seed");
+                try (Git seedGit = Git.init().setDirectory(seedDir.toFile()).call()) {
+                    Files.createDirectories(seedDir.resolve("mappings"));
+                    Files.writeString(seedDir.resolve("mappings/token.json"), "{}");
+                    seedGit.add().addFilepattern(".").call();
+                    seedGit.commit().setMessage("init")
+                            .setAuthor(new PersonIdent("Seed", "seed@test.com"))
+                            .call();
+                    seedGit.push().setRemote(remoteDir.toUri().toString()).call();
+                }
 
-            // create a non-bare repo, add content, push to remote
-            Path seedDir = tempDir.resolve("seed");
-            Git seedGit = Git.init().setDirectory(seedDir.toFile()).call();
-            Files.createDirectories(seedDir.resolve("mappings"));
-            Files.writeString(seedDir.resolve("mappings/token.json"), "{}");
-            seedGit.add().addFilepattern(".").call();
-            seedGit.commit().setMessage("init")
-                    .setAuthor(new PersonIdent("Seed", "seed@test.com"))
-                    .call();
-            seedGit.push().setRemote(remoteDir.toUri().toString()).call();
-            seedGit.close();
-
-            // clone from local remote into the expected directory
-            Path repoDir = tempDir.resolve("test-repo");
-            Git clonedGit = Git.cloneRepository()
-                    .setURI(remoteDir.toUri().toString())
-                    .setDirectory(repoDir.toFile())
-                    .call();
-            clonedGit.close();
+                Path repoDir = tempDir.resolve("test-repo");
+                try (Git clonedGit = Git.cloneRepository()
+                        .setURI(remoteDir.toUri().toString())
+                        .setDirectory(repoDir.toFile())
+                        .call()) {
+                    // cloned, now close so GitService can open it
+                }
+            }
 
             var result = gitService.cloneCardanoTokenRegistryGitRepository();
 
@@ -397,7 +386,6 @@ class GitServiceTest {
 
         @Test
         void returnsEmptyWhenCloneFails() {
-            // organization/project point to non-existent remote, clone will fail
             var result = gitService.cloneCardanoTokenRegistryGitRepository();
 
             assertThat(result).isEmpty();
@@ -405,18 +393,15 @@ class GitServiceTest {
 
         @Test
         void forceCloneDeletesExistingNonGitDir() throws Exception {
-            setField("forceClone", true);
+            ReflectionTestUtils.setField(gitService, "forceClone", true);
 
-            // create a non-git directory at the expected path
             Path repoDir = tempDir.resolve("test-repo");
             Files.createDirectories(repoDir.resolve("mappings"));
             Files.writeString(repoDir.resolve("some-file.txt"), "stale");
 
-            // clone will fail (bad remote), but the directory should have been deleted
             var result = gitService.cloneCardanoTokenRegistryGitRepository();
 
             assertThat(result).isEmpty();
-            // the stale file should be gone (directory was deleted before clone attempt)
             assertThat(repoDir.resolve("some-file.txt")).doesNotExist();
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <version.hamcrest>1.3</version.hamcrest>
         <version.cardano-client-lib>0.7.0</version.cardano-client-lib>
         <version.yaci>0.1.6</version.yaci>
+        <version.jgit>7.1.0.202411261347-r</version.jgit>
     </properties>
 
     <repositories>
@@ -150,6 +151,11 @@
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-all</artifactId>
                 <version>${version.hamcrest}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jgit</groupId>
+                <artifactId>org.eclipse.jgit</artifactId>
+                <version>${version.jgit}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

- **Replaced all 5 `ProcessBuilder`-based git command invocations** in `GitService` with JGit's in-process Java API (`clone`, `pull --rebase`, `log`, `rev-parse HEAD`, `diff --name-only --diff-filter=AM`)
- **Added `org.eclipse.jgit` dependency** (v7.1.0) to parent POM (managed) and common module
- **Added null guards** to `getHeadCommitHash()`, `getMappingDetails()`, and `getChangedFiles()` to prevent NPEs when called before repo initialization
- **Added `@PreDestroy` lifecycle hook** to properly close the JGit repository handle
- **Added 23 unit tests** (`GitServiceTest`) using AssertJ and `@Nested` JUnit 5 structure, organized into 6 groups:
  - `GetHeadCommitHash` (4 tests)
  - `GetMappingDetails` (4 tests)
  - `GetChangedFiles` (8 tests)
  - `ValidateConfig` (2 tests)
  - `Cleanup` (2 tests)
  - `CloneCardanoTokenRegistryGitRepository` (3 tests)

All tests use real JGit repositories in `@TempDir` — no mocking of git internals.

## Test plan

- [x] All 23 new `GitServiceTest` tests pass
- [x] All 44 existing common module tests still pass (67 total)
- [x] Verify full `mvn clean verify` passes in CI
- [ ] Validate end-to-end sync with Docker Compose against the real cardano-token-registry