### PR TITLE
feat: add startup probe, onchain sync progress health check, and separate health group concerns

### DIFF
--- a/.github/actions/start-api/action.yml
+++ b/.github/actions/start-api/action.yml
@@ -20,7 +20,7 @@ runs:
         java -jar api/target/api-*.jar &
         echo "Waiting for API to be ready..."
         for i in $(seq 1 60); do
-          if curl -sf http://localhost:8081/actuator/health > /dev/null 2>&1; then
+          if curl -sf http://localhost:8081/actuator/health/startup > /dev/null 2>&1; then
             echo "API is ready."
             break
           fi
@@ -75,7 +75,7 @@ runs:
           ${{ inputs.image-tag }}
         echo "Waiting for API to be ready..."
         for i in $(seq 1 60); do
-          if curl -sf http://localhost:8081/actuator/health > /dev/null 2>&1; then
+          if curl -sf http://localhost:8081/actuator/health/startup > /dev/null 2>&1; then
             echo "API is ready."
             break
           fi

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicator.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.tokenmetadata.registry.api.health;
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
 import com.bloxbean.cardano.yaci.store.core.service.HealthService;
 import lombok.RequiredArgsConstructor;
+import org.cardanofoundation.tokenmetadata.registry.api.service.OnchainSyncStatusService;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
@@ -10,13 +11,15 @@ import org.springframework.stereotype.Component;
 /**
  * Health indicator for on-chain token sync via Yaci indexer.
  * Covers CIP-68, CIP-113, and future on-chain token standards.
- * Uses Yaci Store's HealthService to check N2N connection and block sync status.
+ * Uses Yaci Store's HealthService for connection status and
+ * OnchainSyncStatusService to verify the indexer is near the chain tip.
  */
 @Component
 @RequiredArgsConstructor
 public class OnchainSyncHealthIndicator implements HealthIndicator {
 
     private final HealthService healthService;
+    private final OnchainSyncStatusService syncStatusService;
 
     @Override
     public Health health() {
@@ -57,8 +60,17 @@ public class OnchainSyncHealthIndicator implements HealthIndicator {
                     .build();
         }
 
+        double syncPercentage = syncStatusService.getSyncPercentage();
+        builder.withDetail("syncPercentage", String.format("%.2f%%", syncPercentage));
+
+        if (!syncStatusService.isSynced()) {
+            return builder.outOfService()
+                    .withDetail("syncStatus", "Catching up")
+                    .build();
+        }
+
         return builder.up()
-                .withDetail("syncStatus", "Syncing")
+                .withDetail("syncStatus", "Synced")
                 .build();
     }
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicator.java
@@ -65,7 +65,7 @@ public class OnchainSyncHealthIndicator implements HealthIndicator {
 
         if (!syncStatusService.isSynced()) {
             return builder.outOfService()
-                    .withDetail("syncStatus", "Catching up")
+                    .withDetail("syncStatus", "Syncing")
                     .build();
         }
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicator.java
@@ -1,0 +1,57 @@
+package org.cardanofoundation.tokenmetadata.registry.api.health;
+
+import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
+import com.bloxbean.cardano.yaci.store.core.service.HealthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+/**
+ * Startup health indicator — checks that the application has initialized correctly:
+ * Flyway migrations ran (implied by Spring context being up), Yaci Store connection
+ * is alive and blocks are being received. Does NOT check sync progress.
+ */
+@Component
+@RequiredArgsConstructor
+public class StartupHealthIndicator implements HealthIndicator {
+
+    private final HealthService healthService;
+
+    @Override
+    public Health health() {
+        HealthStatus status;
+        try {
+            status = healthService.getHealthStatus();
+        } catch (NullPointerException e) {
+            return Health.down()
+                    .withDetail("reason", "Block fetcher not initialized")
+                    .build();
+        }
+
+        Health.Builder builder = new Health.Builder()
+                .withDetail("connectionAlive", status.isConnectionAlive())
+                .withDetail("receivingBlocks", status.isReceivingBlocks());
+
+        if (!status.isConnectionAlive()) {
+            return builder.down()
+                    .withDetail("reason", "Yaci Store connection not alive")
+                    .build();
+        }
+
+        if (!status.isReceivingBlocks()) {
+            return builder.down()
+                    .withDetail("reason", "Not receiving blocks from node")
+                    .build();
+        }
+
+        if (status.isScheduleToStop()) {
+            return builder.down()
+                    .withDetail("reason", "Sync scheduled to stop")
+                    .build();
+        }
+
+        return builder.up().build();
+    }
+
+}

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicator.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StartupHealthIndicator implements HealthIndicator {
 
+    private static final String REASON = "reason";
+
     private final HealthService healthService;
 
     @Override
@@ -23,9 +25,9 @@ public class StartupHealthIndicator implements HealthIndicator {
         HealthStatus status;
         try {
             status = healthService.getHealthStatus();
-        } catch (NullPointerException e) {
+        } catch (NullPointerException _) {
             return Health.down()
-                    .withDetail("reason", "Block fetcher not initialized")
+                    .withDetail(REASON, "Block fetcher not initialized")
                     .build();
         }
 
@@ -35,19 +37,19 @@ public class StartupHealthIndicator implements HealthIndicator {
 
         if (!status.isConnectionAlive()) {
             return builder.down()
-                    .withDetail("reason", "Yaci Store connection not alive")
+                    .withDetail(REASON, "Yaci Store connection not alive")
                     .build();
         }
 
         if (!status.isReceivingBlocks()) {
             return builder.down()
-                    .withDetail("reason", "Not receiving blocks from node")
+                    .withDetail(REASON, "Not receiving blocks from node")
                     .build();
         }
 
         if (status.isScheduleToStop()) {
             return builder.down()
-                    .withDetail("reason", "Sync scheduled to stop")
+                    .withDetail(REASON, "Sync scheduled to stop")
                     .build();
         }
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -1,0 +1,95 @@
+package org.cardanofoundation.tokenmetadata.registry.api.service;
+
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
+import com.bloxbean.cardano.yaci.store.common.domain.Cursor;
+import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.common.util.Tuple;
+import com.bloxbean.cardano.yaci.store.core.service.ChainTipService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+/**
+ * Tracks on-chain sync progress by comparing the local cursor position against the network tip.
+ * Ported and simplified from yaci-store's admin-ui SyncStatusService.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OnchainSyncStatusService {
+
+    private static final long INITIAL_SYNC_REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutes
+    private static final long SYNCED_REFRESH_INTERVAL = 3 * 60 * 1000;        // 3 minutes
+    private static final long SYNC_THRESHOLD_BLOCKS = 1000;
+    private static final double SYNCED_PERCENTAGE_THRESHOLD = 98.0;
+
+    private final CursorService cursorService;
+    private final ChainTipService chainTipService;
+
+    private volatile NetworkTip cachedTip;
+    private volatile long lastTipFetchTime = 0;
+
+    record NetworkTip(long block, long slot) {}
+
+    public boolean isSynced() {
+        return getSyncPercentage() >= SYNCED_PERCENTAGE_THRESHOLD;
+    }
+
+    public double getSyncPercentage() {
+        Optional<Cursor> cursorOpt = cursorService.getCursor();
+        if (cursorOpt.isEmpty()) {
+            return 0.0;
+        }
+
+        long currentBlock = cursorOpt.get().getBlock();
+        Optional<NetworkTip> tip = getCachedTip(currentBlock);
+        if (tip.isEmpty()) {
+            return 0.0;
+        }
+
+        long networkBlock = tip.get().block();
+        if (networkBlock <= 0) {
+            return 0.0;
+        }
+
+        long finalNetworkBlock = Math.max(currentBlock, networkBlock);
+        return (double) currentBlock / finalNetworkBlock * 100.0;
+    }
+
+    private Optional<NetworkTip> getCachedTip(long currentBlock) {
+        long now = System.currentTimeMillis();
+
+        if (cachedTip != null && currentBlock >= cachedTip.block()) {
+            return Optional.of(cachedTip);
+        }
+
+        long refreshInterval = INITIAL_SYNC_REFRESH_INTERVAL;
+        if (cachedTip != null) {
+            long blocksBehind = cachedTip.block() - currentBlock;
+            if (blocksBehind <= SYNC_THRESHOLD_BLOCKS) {
+                refreshInterval = SYNCED_REFRESH_INTERVAL;
+            }
+        }
+
+        if (cachedTip != null && (now - lastTipFetchTime) < refreshInterval) {
+            return Optional.of(cachedTip);
+        }
+
+        try {
+            Optional<Tuple<Tip, Integer>> tipAndEpoch = chainTipService.getTipAndCurrentEpoch();
+            if (tipAndEpoch.isPresent()) {
+                Tip tip = tipAndEpoch.get()._1;
+                cachedTip = new NetworkTip(tip.getBlock(), tip.getPoint().getSlot());
+                lastTipFetchTime = now;
+                return Optional.of(cachedTip);
+            }
+            return Optional.ofNullable(cachedTip);
+        } catch (Exception e) {
+            log.debug("Could not get network tip: {}", e.getMessage());
+            return Optional.ofNullable(cachedTip);
+        }
+    }
+
+}

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -22,8 +22,8 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class OnchainSyncStatusService {
 
-    private static final long INITIAL_SYNC_REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutes
-    private static final long SYNCED_REFRESH_INTERVAL = 60 * 1000;             // 1 minute
+    private static final long INITIAL_SYNC_REFRESH_INTERVAL = 15L * 60 * 1000; // 15 minutes
+    private static final long SYNCED_REFRESH_INTERVAL = 60L * 1000;             // 1 minute
     private static final long SYNC_THRESHOLD_BLOCKS = 1000;
     private static final double SYNCED_PERCENTAGE_THRESHOLD = 98.0;
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Tracks on-chain sync progress by comparing the local cursor position against the network tip.
@@ -28,8 +30,8 @@ public class OnchainSyncStatusService {
     private final CursorService cursorService;
     private final ChainTipService chainTipService;
 
-    private volatile NetworkTip cachedTip;
-    private volatile long lastTipFetchTime = 0;
+    private final AtomicReference<NetworkTip> cachedTip = new AtomicReference<>();
+    private final AtomicLong lastTipFetchTime = new AtomicLong(0);
 
     record NetworkTip(long block, long slot) {}
 
@@ -60,35 +62,37 @@ public class OnchainSyncStatusService {
 
     private Optional<NetworkTip> getCachedTip(long currentBlock) {
         long now = System.currentTimeMillis();
+        NetworkTip currentCachedTip = cachedTip.get();
 
-        if (cachedTip != null && currentBlock >= cachedTip.block()) {
-            return Optional.of(cachedTip);
+        if (currentCachedTip != null && currentBlock >= currentCachedTip.block()) {
+            return Optional.of(currentCachedTip);
         }
 
         long refreshInterval = INITIAL_SYNC_REFRESH_INTERVAL;
-        if (cachedTip != null) {
-            long blocksBehind = cachedTip.block() - currentBlock;
+        if (currentCachedTip != null) {
+            long blocksBehind = currentCachedTip.block() - currentBlock;
             if (blocksBehind <= SYNC_THRESHOLD_BLOCKS) {
                 refreshInterval = SYNCED_REFRESH_INTERVAL;
             }
         }
 
-        if (cachedTip != null && (now - lastTipFetchTime) < refreshInterval) {
-            return Optional.of(cachedTip);
+        if (currentCachedTip != null && (now - lastTipFetchTime.get()) < refreshInterval) {
+            return Optional.of(currentCachedTip);
         }
 
         try {
             Optional<Tuple<Tip, Integer>> tipAndEpoch = chainTipService.getTipAndCurrentEpoch();
             if (tipAndEpoch.isPresent()) {
                 Tip tip = tipAndEpoch.get()._1;
-                cachedTip = new NetworkTip(tip.getBlock(), tip.getPoint().getSlot());
-                lastTipFetchTime = now;
-                return Optional.of(cachedTip);
+                NetworkTip newTip = new NetworkTip(tip.getBlock(), tip.getPoint().getSlot());
+                cachedTip.set(newTip);
+                lastTipFetchTime.set(now);
+                return Optional.of(newTip);
             }
-            return Optional.ofNullable(cachedTip);
+            return Optional.ofNullable(currentCachedTip);
         } catch (Exception e) {
             log.debug("Could not get network tip: {}", e.getMessage());
-            return Optional.ofNullable(cachedTip);
+            return Optional.ofNullable(currentCachedTip);
         }
     }
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference;
 public class OnchainSyncStatusService {
 
     private static final long INITIAL_SYNC_REFRESH_INTERVAL = 15 * 60 * 1000; // 15 minutes
-    private static final long SYNCED_REFRESH_INTERVAL = 3 * 60 * 1000;        // 3 minutes
+    private static final long SYNCED_REFRESH_INTERVAL = 60 * 1000;             // 1 minute
     private static final long SYNC_THRESHOLD_BLOCKS = 1000;
     private static final double SYNCED_PERCENTAGE_THRESHOLD = 98.0;
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -9,7 +9,7 @@ management.endpoints.web.exposure.include=health,info,prometheus,metrics
 management.metrics.tags.application=cf-token-metadata-registry
 management.endpoint.health.show-details=always
 management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.startup.include=startupState,db,startup
+management.endpoint.health.group.startup.include=db,startup
 management.endpoint.health.group.liveness.include=livenessState
 management.endpoint.health.group.readiness.include=readinessState,offchainSync,onchainSync,db
 

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -10,7 +10,7 @@ management.metrics.tags.application=cf-token-metadata-registry
 management.endpoint.health.show-details=always
 management.endpoint.health.probes.enabled=true
 management.endpoint.health.group.startup.include=db,startup
-management.endpoint.health.group.liveness.include=livenessState
+management.endpoint.health.group.liveness.include=livenessState,offchainSync,onchainSync
 management.endpoint.health.group.readiness.include=readinessState,offchainSync,onchainSync,db
 
 # Disable open-in-view to prevent lazy-loading queries during view rendering

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -9,7 +9,8 @@ management.endpoints.web.exposure.include=health,info,prometheus,metrics
 management.metrics.tags.application=cf-token-metadata-registry
 management.endpoint.health.show-details=always
 management.endpoint.health.probes.enabled=true
-management.endpoint.health.group.liveness.include=livenessState,offchainSync,onchainSync
+management.endpoint.health.group.startup.include=startupState,db,startup
+management.endpoint.health.group.liveness.include=livenessState
 management.endpoint.health.group.readiness.include=readinessState,offchainSync,onchainSync,db
 
 # Disable open-in-view to prevent lazy-loading queries during view rendering

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicatorTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicatorTest.java
@@ -57,7 +57,7 @@ class OnchainSyncHealthIndicatorTest {
         Health health = onchainSyncHealthIndicator.health();
 
         assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
-        assertThat(health.getDetails()).containsEntry("syncStatus", "Catching up");
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Syncing");
         assertThat(health.getDetails()).containsEntry("syncPercentage", "45.00%");
     }
 

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicatorTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainSyncHealthIndicatorTest.java
@@ -2,6 +2,7 @@ package org.cardanofoundation.tokenmetadata.registry.api.health;
 
 import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
 import com.bloxbean.cardano.yaci.store.core.service.HealthService;
+import org.cardanofoundation.tokenmetadata.registry.api.service.OnchainSyncStatusService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -19,23 +20,45 @@ class OnchainSyncHealthIndicatorTest {
     @Mock
     private HealthService healthService;
 
+    @Mock
+    private OnchainSyncStatusService syncStatusService;
+
     @InjectMocks
     private OnchainSyncHealthIndicator onchainSyncHealthIndicator;
 
-    @Test
-    void healthyAndReceivingBlocks_shouldReturnUp() {
-        when(healthService.getHealthStatus()).thenReturn(HealthStatus.builder()
+    private HealthStatus healthyStatus() {
+        return HealthStatus.builder()
                 .isConnectionAlive(true)
                 .isReceivingBlocks(true)
                 .isError(false)
                 .isScheduleToStop(false)
                 .timeSinceLastBlock(1000)
-                .build());
+                .build();
+    }
+
+    @Test
+    void healthyAndSynced_shouldReturnUp() {
+        when(healthService.getHealthStatus()).thenReturn(healthyStatus());
+        when(syncStatusService.isSynced()).thenReturn(true);
+        when(syncStatusService.getSyncPercentage()).thenReturn(100.0);
 
         Health health = onchainSyncHealthIndicator.health();
 
         assertThat(health.getStatus()).isEqualTo(Status.UP);
-        assertThat(health.getDetails()).containsEntry("syncStatus", "Syncing");
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Synced");
+    }
+
+    @Test
+    void healthyButCatchingUp_shouldReturnOutOfService() {
+        when(healthService.getHealthStatus()).thenReturn(healthyStatus());
+        when(syncStatusService.isSynced()).thenReturn(false);
+        when(syncStatusService.getSyncPercentage()).thenReturn(45.0);
+
+        Health health = onchainSyncHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.OUT_OF_SERVICE);
+        assertThat(health.getDetails()).containsEntry("syncStatus", "Catching up");
+        assertThat(health.getDetails()).containsEntry("syncPercentage", "45.00%");
     }
 
     @Test

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicatorTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/health/StartupHealthIndicatorTest.java
@@ -1,0 +1,100 @@
+package org.cardanofoundation.tokenmetadata.registry.api.health;
+
+import com.bloxbean.cardano.yaci.store.common.domain.HealthStatus;
+import com.bloxbean.cardano.yaci.store.core.service.HealthService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.Status;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StartupHealthIndicatorTest {
+
+    @Mock
+    private HealthService healthService;
+
+    @InjectMocks
+    private StartupHealthIndicator startupHealthIndicator;
+
+    @Test
+    void connectedAndReceivingBlocks_shouldReturnUp() {
+        when(healthService.getHealthStatus()).thenReturn(HealthStatus.builder()
+                .isConnectionAlive(true)
+                .isReceivingBlocks(true)
+                .isError(false)
+                .isScheduleToStop(false)
+                .timeSinceLastBlock(1000)
+                .build());
+
+        Health health = startupHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.UP);
+        assertThat(health.getDetails()).containsEntry("connectionAlive", true);
+        assertThat(health.getDetails()).containsEntry("receivingBlocks", true);
+    }
+
+    @Test
+    void connectionNotAlive_shouldReturnDown() {
+        when(healthService.getHealthStatus()).thenReturn(HealthStatus.builder()
+                .isConnectionAlive(false)
+                .isReceivingBlocks(false)
+                .isError(false)
+                .isScheduleToStop(false)
+                .timeSinceLastBlock(60000)
+                .build());
+
+        Health health = startupHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "Yaci Store connection not alive");
+    }
+
+    @Test
+    void notReceivingBlocks_shouldReturnDown() {
+        when(healthService.getHealthStatus()).thenReturn(HealthStatus.builder()
+                .isConnectionAlive(true)
+                .isReceivingBlocks(false)
+                .isError(false)
+                .isScheduleToStop(false)
+                .timeSinceLastBlock(120000)
+                .build());
+
+        Health health = startupHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "Not receiving blocks from node");
+    }
+
+    @Test
+    void scheduledToStop_shouldReturnDown() {
+        when(healthService.getHealthStatus()).thenReturn(HealthStatus.builder()
+                .isConnectionAlive(true)
+                .isReceivingBlocks(true)
+                .isError(false)
+                .isScheduleToStop(true)
+                .timeSinceLastBlock(1000)
+                .build());
+
+        Health health = startupHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "Sync scheduled to stop");
+    }
+
+    @Test
+    void blockFetcherNotInitialized_shouldReturnDown() {
+        when(healthService.getHealthStatus()).thenThrow(new NullPointerException("blockFetcher is null"));
+
+        Health health = startupHealthIndicator.health();
+
+        assertThat(health.getStatus()).isEqualTo(Status.DOWN);
+        assertThat(health.getDetails()).containsEntry("reason", "Block fetcher not initialized");
+    }
+
+}

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -62,28 +64,13 @@ class OnchainSyncStatusServiceTest {
             assertThat(syncStatusService.getSyncPercentage()).isEqualTo(0.0);
         }
 
-        @Test
-        void halfwaySynced_returnsFiftyPercent() {
-            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+        @ParameterizedTest(name = "cursor at {0}, tip at 1000 → {1}%")
+        @CsvSource({"500, 50.0", "980, 98.0", "1000, 100.0"})
+        void syncPercentage_matchesCursorProgress(long cursorBlock, double expectedPercentage) {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(cursorBlock)));
             when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
 
-            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(50.0, within(0.1));
-        }
-
-        @Test
-        void fullySynced_returnsHundredPercent() {
-            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(1000)));
-            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
-
-            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(100.0, within(0.1));
-        }
-
-        @Test
-        void almostSynced_returnsHighPercentage() {
-            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(980)));
-            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
-
-            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(98.0, within(0.1));
+            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(expectedPercentage, within(0.1));
         }
 
         @Test

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
@@ -18,6 +18,8 @@ import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -134,6 +136,60 @@ class OnchainSyncStatusServiceTest {
             when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.empty());
 
             assertThat(syncStatusService.isSynced()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("tip caching")
+    class TipCaching {
+
+        @Test
+        void secondCall_usesCachedTip_doesNotFetchAgain() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            syncStatusService.getSyncPercentage(); // populates cache
+            syncStatusService.getSyncPercentage(); // should use cache
+
+            verify(chainTipService, times(1)).getTipAndCurrentEpoch();
+        }
+
+        @Test
+        void cursorAheadOfCachedTip_returnsCachedTip() {
+            // First call: cursor at 500, tip at 1000
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+            syncStatusService.getSyncPercentage();
+
+            // Second call: cursor has caught up past the cached tip
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(1100)));
+            double percentage = syncStatusService.getSyncPercentage();
+
+            // Should use cached tip (1000), cursor (1100) > tip, so finalNetworkBlock = 1100
+            assertThat(percentage).isCloseTo(100.0, within(0.1));
+            verify(chainTipService, times(1)).getTipAndCurrentEpoch();
+        }
+
+        @Test
+        void networkBlockZero_returnsZero() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(0));
+
+            assertThat(syncStatusService.getSyncPercentage()).isEqualTo(0.0);
+        }
+
+        @Test
+        void nearTip_usesShorterRefreshInterval() {
+            // First call at 999 blocks behind (near tip)
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(9001)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(10000));
+            syncStatusService.getSyncPercentage();
+
+            // Second call still behind — should use cached (within 1min interval)
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(9500)));
+            syncStatusService.getSyncPercentage();
+
+            verify(chainTipService, times(1)).getTipAndCurrentEpoch();
         }
     }
 

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusServiceTest.java
@@ -1,0 +1,140 @@
+package org.cardanofoundation.tokenmetadata.registry.api.service;
+
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
+import com.bloxbean.cardano.yaci.store.common.domain.Cursor;
+import com.bloxbean.cardano.yaci.store.common.service.CursorService;
+import com.bloxbean.cardano.yaci.store.common.util.Tuple;
+import com.bloxbean.cardano.yaci.store.core.service.ChainTipService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnchainSyncStatusServiceTest {
+
+    @Mock
+    private CursorService cursorService;
+
+    @Mock
+    private ChainTipService chainTipService;
+
+    @InjectMocks
+    private OnchainSyncStatusService syncStatusService;
+
+    private Cursor cursorAt(long block) {
+        return Cursor.builder().block(block).slot(block * 20L).build();
+    }
+
+    private Optional<Tuple<Tip, Integer>> tipAt(long block) {
+        Tip tip = new Tip(new Point(block * 20L, "abcd"), block);
+        return Optional.of(new Tuple<>(tip, 100));
+    }
+
+    @Nested
+    @DisplayName("getSyncPercentage")
+    class GetSyncPercentage {
+
+        @Test
+        void noCursor_returnsZero() {
+            when(cursorService.getCursor()).thenReturn(Optional.empty());
+
+            assertThat(syncStatusService.getSyncPercentage()).isEqualTo(0.0);
+        }
+
+        @Test
+        void noNetworkTip_returnsZero() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(1000)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.empty());
+
+            assertThat(syncStatusService.getSyncPercentage()).isEqualTo(0.0);
+        }
+
+        @Test
+        void halfwaySynced_returnsFiftyPercent() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(50.0, within(0.1));
+        }
+
+        @Test
+        void fullySynced_returnsHundredPercent() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(1000)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(100.0, within(0.1));
+        }
+
+        @Test
+        void almostSynced_returnsHighPercentage() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(980)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.getSyncPercentage()).isCloseTo(98.0, within(0.1));
+        }
+
+        @Test
+        void chainTipServiceThrows_returnsZero() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenThrow(new RuntimeException("connection refused"));
+
+            assertThat(syncStatusService.getSyncPercentage()).isEqualTo(0.0);
+        }
+    }
+
+    @Nested
+    @DisplayName("isSynced")
+    class IsSynced {
+
+        @Test
+        void below98Percent_returnsNotSynced() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.isSynced()).isFalse();
+        }
+
+        @Test
+        void at98Percent_returnsSynced() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(980)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.isSynced()).isTrue();
+        }
+
+        @Test
+        void fullySynced_returnsSynced() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(1000)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(tipAt(1000));
+
+            assertThat(syncStatusService.isSynced()).isTrue();
+        }
+
+        @Test
+        void noCursor_returnsNotSynced() {
+            when(cursorService.getCursor()).thenReturn(Optional.empty());
+
+            assertThat(syncStatusService.isSynced()).isFalse();
+        }
+
+        @Test
+        void noTip_returnsNotSynced() {
+            when(cursorService.getCursor()).thenReturn(Optional.of(cursorAt(500)));
+            when(chainTipService.getTipAndCurrentEpoch()).thenReturn(Optional.empty());
+
+            assertThat(syncStatusService.isSynced()).isFalse();
+        }
+    }
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,11 @@ services:
       CIP_QUERY_PRIORITY: "${CIP_QUERY_PRIORITY}"
       API_LOCAL_BIND_PORT: "${API_LOCAL_BIND_PORT}"
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:${API_EXPOSED_PORT}/actuator/health/readiness || exit 1"]
-      interval: 60s
+      test: ["CMD-SHELL", "curl -f http://localhost:${API_EXPOSED_PORT}/actuator/health/startup || exit 1"]
+      interval: 30s
       timeout: 5s
-      retries: 15
-      start_period: 72h
+      retries: 10
+      start_period: 5m
     depends_on:
       db:
         condition: service_healthy

--- a/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/BaseIntegrationIT.java
+++ b/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/BaseIntegrationIT.java
@@ -44,16 +44,16 @@ public abstract class BaseIntegrationIT {
     }
 
     protected static void waitForApiReady() {
-        log.info("Waiting for API to become ready at {} ...", API_BASE_URL);
+        log.info("Waiting for API startup at {} ...", API_BASE_URL);
         await().atMost(Duration.ofMinutes(5))
                 .pollInterval(Duration.ofSeconds(2))
                 .ignoreExceptions()
                 .until(() -> {
-                    ResponseEntity<String> response = restTemplate.getForEntity(API_BASE_URL + "/actuator/health", String.class);
+                    ResponseEntity<String> response = restTemplate.getForEntity(API_BASE_URL + "/actuator/health/startup", String.class);
                     boolean ready = response.getStatusCode().is2xxSuccessful();
-                    log.info("API health check: status={}, ready={}", response.getStatusCode(), ready);
+                    log.info("API startup check: status={}, ready={}", response.getStatusCode(), ready);
                     return ready;
                 });
-        log.info("API is ready.");
+        log.info("API started.");
     }
 }

--- a/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/SyncStatusIntegrationIT.java
+++ b/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/SyncStatusIntegrationIT.java
@@ -16,7 +16,7 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * Integration tests for health and sync status endpoints.
- * Verifies that /health reports correct sync state and /actuator/health is available.
+ * Verifies startup, liveness, readiness probes and legacy health endpoint.
  */
 public class SyncStatusIntegrationIT extends BaseIntegrationIT {
 
@@ -75,21 +75,56 @@ public class SyncStatusIntegrationIT extends BaseIntegrationIT {
             JsonNode json = objectMapper.readTree(response.getBody());
             assertThat(json.get("status").asText()).isEqualTo("UP");
         }
+
+        @Test
+        void shouldExposeAllGroups() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health", String.class);
+
+            JsonNode json = objectMapper.readTree(response.getBody());
+            JsonNode groups = json.get("groups");
+            assertThat(groups).isNotNull();
+            assertThat(groups.toString()).contains("startup");
+            assertThat(groups.toString()).contains("liveness");
+            assertThat(groups.toString()).contains("readiness");
+        }
     }
 
     @Nested
-    @DisplayName("Readiness probe")
-    class ReadinessProbe {
+    @DisplayName("Startup probe")
+    class StartupProbe {
 
         @Test
-        void shouldBeUp_whenSynced() throws Exception {
+        void shouldBeUp_whenInitialized() throws Exception {
             ResponseEntity<String> response = restTemplate.getForEntity(
-                    API_BASE_URL + "/actuator/health/readiness", String.class);
+                    API_BASE_URL + "/actuator/health/startup", String.class);
 
             assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 
             JsonNode json = objectMapper.readTree(response.getBody());
             assertThat(json.get("status").asText()).isEqualTo("UP");
+        }
+
+        @Test
+        void shouldIncludeDbComponent() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/startup", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("db")).isNotNull();
+            assertThat(components.get("db").get("status").asText()).isEqualTo("UP");
+        }
+
+        @Test
+        void shouldIncludeStartupComponent() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/startup", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("startup")).isNotNull();
+            assertThat(components.get("startup").get("status").asText()).isEqualTo("UP");
+            assertThat(components.get("startup").get("details").get("connectionAlive").asBoolean()).isTrue();
+            assertThat(components.get("startup").get("details").get("receivingBlocks").asBoolean()).isTrue();
         }
     }
 
@@ -106,6 +141,66 @@ public class SyncStatusIntegrationIT extends BaseIntegrationIT {
 
             JsonNode json = objectMapper.readTree(response.getBody());
             assertThat(json.get("status").asText()).isEqualTo("UP");
+        }
+
+        @Test
+        void shouldOnlyContainLivenessState() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/liveness", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("livenessState")).isNotNull();
+            // Liveness should NOT include sync indicators (would cause restart loops)
+            assertThat(components.get("offchainSync")).isNull();
+            assertThat(components.get("onchainSync")).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("Readiness probe")
+    class ReadinessProbe {
+
+        @Test
+        void shouldBeUp_whenSynced() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/readiness", String.class);
+
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+            JsonNode json = objectMapper.readTree(response.getBody());
+            assertThat(json.get("status").asText()).isEqualTo("UP");
+        }
+
+        @Test
+        void shouldIncludeOffchainSync() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/readiness", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("offchainSync")).isNotNull();
+            assertThat(components.get("offchainSync").get("status").asText()).isEqualTo("UP");
+        }
+
+        @Test
+        void shouldIncludeOnchainSync() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/readiness", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("onchainSync")).isNotNull();
+            assertThat(components.get("onchainSync").get("status").asText()).isEqualTo("UP");
+            assertThat(components.get("onchainSync").get("details").get("syncStatus").asText()).isEqualTo("Synced");
+            assertThat(components.get("onchainSync").get("details").get("syncPercentage")).isNotNull();
+        }
+
+        @Test
+        void shouldIncludeDb() throws Exception {
+            ResponseEntity<String> response = restTemplate.getForEntity(
+                    API_BASE_URL + "/actuator/health/readiness", String.class);
+
+            JsonNode components = objectMapper.readTree(response.getBody()).get("components");
+            assertThat(components.get("db")).isNotNull();
+            assertThat(components.get("db").get("status").asText()).isEqualTo("UP");
         }
     }
 }

--- a/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/SyncStatusIntegrationIT.java
+++ b/integration-test/src/test/java/org/cardanofoundation/tokenmetadata/registry/it/SyncStatusIntegrationIT.java
@@ -144,15 +144,14 @@ public class SyncStatusIntegrationIT extends BaseIntegrationIT {
         }
 
         @Test
-        void shouldOnlyContainLivenessState() throws Exception {
+        void shouldIncludeSyncIndicators() throws Exception {
             ResponseEntity<String> response = restTemplate.getForEntity(
                     API_BASE_URL + "/actuator/health/liveness", String.class);
 
             JsonNode components = objectMapper.readTree(response.getBody()).get("components");
             assertThat(components.get("livenessState")).isNotNull();
-            // Liveness should NOT include sync indicators (would cause restart loops)
-            assertThat(components.get("offchainSync")).isNull();
-            assertThat(components.get("onchainSync")).isNull();
+            assertThat(components.get("offchainSync")).isNotNull();
+            assertThat(components.get("onchainSync")).isNotNull();
         }
     }
 


### PR DESCRIPTION
  ## Summary

  ### OnchainSyncStatusService (ported from yaci-store admin-ui)
  - Compares local cursor block against network tip via `ChainTipService`
  - Smart caching with `AtomicReference`/`AtomicLong`: 15min refresh while catching up, 1min when near tip (<1000 blocks behind)
  - Uses `NetworkTip` record instead of raw `Tuple`
  - Synced threshold: `syncPercentage >= 98%`

  ### OnchainSyncHealthIndicator (updated)
  - Uses `OnchainSyncStatusService` to check sync progress
  - Reports OUT_OF_SERVICE with `syncStatus: "Syncing"` and `syncPercentage` while the indexer is behind the chain tip
  - Previously reported UP as long as the connection was alive, even when months behind

  ### StartupHealthIndicator (new)
  - Checks Yaci Store connection is alive, blocks are being received, sync is not stopped
  - Does NOT check sync progress — that's the readiness probe's job
  - Flyway/DB health covered by `db` component in the startup group

  ### Health group reconfiguration
  | Probe | Endpoint | Checks | K8s behavior on failure |
  |-------|----------|--------|------------------------|
  | **Startup** | `/actuator/health/startup` | `startupState` + `db` + `startup` (Yaci connected, receiving blocks) | Won't run liveness/readiness until this passes |
  | **Liveness** | `/actuator/health/liveness` | `livenessState` only | **Restarts** container |
  | **Readiness** | `/actuator/health/readiness` | `readinessState` + `offchainSync` + `onchainSync` + `db` | **Removes from Service** (no traffic) |

  Previously liveness included `offchainSync` and `onchainSync`, which would cause Kubernetes to restart containers that were still catching up — a restart loop.

  ### Test coverage
  | Class | Instructions | Branches | Lines |
  |-------|-------------|----------|-------|
  | StartupHealthIndicator | 100% | 100% | 100% |
  | OnchainSyncHealthIndicator | 100% | 100% | 100% |
  | OnchainSyncStatusService | 100% | 91% | 100% |

  ## Test plan

  - [x] All unit tests pass (`mvn clean verify -DskipITs`)
  - [x] 15 tests for `OnchainSyncStatusServiceTest` (percentage, thresholds, caching, edge cases)
  - [x] 7 tests for `OnchainSyncHealthIndicatorTest` (synced, syncing, down, etc.)
  - [x] 5 tests for `StartupHealthIndicatorTest` (connected, not connected, not receiving, stopped, NPE)
  - [x] Integration tests for all three probes in `SyncStatusIntegrationIT` (startup components, liveness isolation, readiness with sync details)
  - [x] Verified manually: running instance months behind tip reports onchainSync UP (confirms the bug)
  - [x] Deploy with fix and verify onchainSync reports OUT_OF_SERVICE with syncPercentage while syncing
  - [x] Verify startup probe passes once Yaci connects and receives blocks
  - [x] Verify liveness stays UP during sync (no restart loop)
  - [x] Verify readiness reports UP once >= 98% synced