### PR TITLE
docs: add Architecture Decision Records

### DIFF
--- a/adr/000-overview.md
+++ b/adr/000-overview.md
@@ -1,0 +1,89 @@
+# ADR-000: Architecture Decision Records Overview
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The CF Token Metadata Registry is a CIP-26 compliant offchain metadata registry for Cardano tokens, extended with CIP-68 on-chain metadata support. As the project has evolved through multiple releases, several significant architectural decisions have been made that shape its design, deployment, and operation.
+
+This document serves as an index and navigation guide to all Architecture Decision Records (ADRs) in this project, providing a high-level map of the key decisions and their relationships.
+
+## Architecture at a Glance
+
+The system is a multi-module Spring Boot 3 application composed of:
+
+- **api** - REST API server implementing CIP-26/CIP-68 metadata queries
+- **job** - Background processor for syncing token metadata from GitHub
+- **common** - Shared domain models, entities, services, and repositories
+- **cli** - Command-line tools for metadata operations
+
+Data flows into the system from two sources:
+1. **Off-chain**: GitHub repository (`cardano-token-registry`) synced via JGit
+2. **On-chain**: Cardano blockchain indexed via Yaci Store for CIP-68 reference NFTs
+
+The API exposes both a legacy V1 (CIP-26 only) and an enhanced V2 (CIP-26 + CIP-68 with configurable priority) interface.
+
+## ADR Index
+
+### Project Structure & Technology
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](001-multi-module-maven-structure.md) | Multi-Module Maven Project Structure | Accepted |
+| [ADR-002](002-spring-boot-virtual-threads-jdk25.md) | Spring Boot 3 with Virtual Threads on JDK 25 | Accepted |
+| [ADR-003](003-graalvm-native-image-support.md) | GraalVM Native Image Support | Accepted |
+
+### Data & Standards
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-004](004-cip26-cip68-dual-standard.md) | CIP-26 and CIP-68 Dual Standard Support | Accepted |
+| [ADR-005](005-postgresql-jsonb-metadata.md) | PostgreSQL with JSONB for Extensible Metadata | Accepted |
+| [ADR-006](006-flyway-database-migrations.md) | Flyway for Database Schema Management | Accepted |
+
+### Data Ingestion
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-007](007-yaci-store-onchain-indexing.md) | Yaci Store for On-Chain Data Indexing | Accepted |
+| [ADR-008](008-jgit-git-operations.md) | JGit for Git Operations | Accepted |
+| [ADR-009](009-incremental-github-sync.md) | Incremental GitHub Sync with Commit Tracking | Accepted |
+
+### API Design
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-010](010-v2-api-query-priority.md) | V2 API with Query Priority Model | Accepted |
+
+### Operations & Observability
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-011](011-health-check-groups-kubernetes.md) | Health Check Groups for Kubernetes Probes | Accepted |
+| [ADR-012](012-prometheus-business-metrics.md) | Prometheus Metrics with Custom Business Counters | Accepted |
+| [ADR-013](013-structured-logging-ecs.md) | Structured Logging with ECS Format | Accepted |
+
+### CI/CD & Release
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-014](014-release-please-versioning.md) | Release-Please for Automated Versioning | Accepted |
+
+## How to Use ADRs
+
+Each ADR follows a consistent format:
+
+- **Status**: Current state (Proposed, Accepted, Deprecated, Superseded)
+- **Date**: When the decision was made or last updated
+- **Context**: The problem or situation that motivated the decision
+- **Decision**: What was decided and why
+- **Consequences**: The resulting impact, both positive and negative
+- **Alternatives Considered**: Other options that were evaluated
+
+To propose a new ADR, create a new file following the naming convention `NNN-short-title.md` and update this index.

--- a/adr/001-multi-module-maven-structure.md
+++ b/adr/001-multi-module-maven-structure.md
@@ -1,0 +1,46 @@
+# ADR-001: Multi-Module Maven Project Structure
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The CF Token Metadata Registry serves multiple distinct functions: exposing a REST API for metadata queries, running background synchronization jobs against GitHub, providing CLI tooling for metadata operations, and sharing domain models across these concerns. A single-module project would conflate these responsibilities, making it difficult to deploy, test, and evolve them independently.
+
+## Decision
+
+We structure the project as a multi-module Maven build with the following modules:
+
+- **api**: Spring Boot web application serving the REST API, integrating Yaci Store for on-chain data, and exposing health/metrics endpoints.
+- **job**: Standalone Spring Boot `CommandLineRunner` for batch metadata synchronization from GitHub. Can be deployed and scheduled independently.
+- **common**: Shared domain models (JPA entities), repositories, services (e.g., `TokenMetadataSyncService`, `GitService`), and utilities. Has no Spring Boot starter of its own.
+- **cli**: Command-line tool using Apache Commons CLI for metadata operations (init, validate). Runs as a non-web Spring Boot application.
+- **integration-test**: End-to-end tests that require a running API and database.
+
+The root `pom.xml` defines shared dependency versions, plugin configurations, and the module ordering. Each module declares only the dependencies it needs.
+
+## Consequences
+
+### Positive
+
+- **Independent deployment**: The API, job, and CLI can be built and deployed as separate artifacts with different lifecycles.
+- **Clear dependency direction**: `common` has no upward dependencies; `api` and `job` depend on `common` but not on each other.
+- **Smaller artifacts**: Each deployable JAR contains only its required dependencies, reducing image size and startup time.
+- **Focused testing**: Unit tests run per-module; integration tests are isolated in their own module and only executed when infrastructure is available.
+
+### Negative
+
+- **Build complexity**: Multi-module Maven builds require careful dependency management and can slow down full rebuilds.
+- **Shared code governance**: Changes to `common` affect all downstream modules, requiring cross-module testing.
+- **Version coordination**: All modules share the same version (`${revision}` property), making independent versioning impossible without restructuring.
+
+## Alternatives Considered
+
+- **Monolithic single-module**: Simpler build but would force deploying unused code (e.g., CLI dependencies in the API container) and complicate separation of concerns.
+- **Gradle build**: Offers better incremental builds and build caching, but Maven is the established choice in the Cardano Foundation Java ecosystem and aligns with team expertise.
+- **Separate repositories per module**: Maximum independence but introduces coordination overhead for shared domain changes and complicates atomic cross-module updates.

--- a/adr/002-spring-boot-virtual-threads-jdk25.md
+++ b/adr/002-spring-boot-virtual-threads-jdk25.md
@@ -1,0 +1,53 @@
+# ADR-002: Spring Boot 3 with Virtual Threads on JDK 25
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry API handles concurrent metadata queries and background blockchain synchronization. Traditional platform threads impose memory overhead and limit scalability under high concurrency. With the project targeting modern JDK releases, we had the opportunity to adopt virtual threads (Project Loom), which became production-ready in JDK 21 and have matured further in JDK 25.
+
+Spring Boot 3.5.x provides first-class support for virtual threads through a single configuration property, making adoption straightforward.
+
+## Decision
+
+We run the application on JDK 25 with Spring Boot 3.5.12 and enable virtual threads via:
+
+```properties
+spring.threads.virtual.enabled=true
+```
+
+This causes Spring Boot to use virtual threads for request handling (Tomcat), scheduled tasks, and async operations. The Docker images use Eclipse Temurin 25 (both JDK for build and JRE for runtime).
+
+Key version choices in the current stack:
+- Java 25
+- Spring Boot 3.5.12
+- Yaci Store 2.0.0
+- Cardano Client Library 0.7.1
+- PostgreSQL 17
+
+## Consequences
+
+### Positive
+
+- **Improved concurrency**: Virtual threads allow the API to handle many more concurrent requests without increasing memory consumption, particularly beneficial during bulk metadata queries.
+- **Simplified async code**: No need for reactive programming or manual thread pool tuning. Blocking I/O (database, Git operations) works naturally with virtual threads.
+- **Future-proof**: JDK 25 provides access to the latest language features, security patches, and performance improvements.
+- **Spring ecosystem alignment**: Spring Boot 3.5.x is designed for JDK 21+ with full virtual thread integration across web, data, and messaging starters.
+
+### Negative
+
+- **Runtime requirement**: Deployments must use JDK 25+, which may not be available in all environments.
+- **Library compatibility**: Some libraries may not be fully compatible with virtual threads (e.g., those using `ThreadLocal` extensively or `synchronized` blocks for I/O). This requires validation of the dependency tree.
+- **Debugging complexity**: Virtual thread stack traces and thread dumps differ from platform threads, requiring updated tooling and operational knowledge.
+
+## Alternatives Considered
+
+- **JDK 21 LTS**: More conservative choice with virtual thread support, but misses improvements in JDK 22-25. We chose to stay current given the containerized deployment model.
+- **Reactive stack (WebFlux)**: Non-blocking by design but imposes a reactive programming model throughout the codebase, significantly increasing complexity for a primarily CRUD-like API.
+- **Platform threads with tuned pools**: The traditional approach, but virtual threads provide better scalability with less configuration.

--- a/adr/003-graalvm-native-image-support.md
+++ b/adr/003-graalvm-native-image-support.md
@@ -1,0 +1,49 @@
+# ADR-003: GraalVM Native Image Support
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+Container startup time and memory footprint matter in cloud-native deployments, particularly for Kubernetes environments where pods need to scale quickly and health probes have tight timeouts. GraalVM native images compile Java applications ahead-of-time (AOT) into standalone executables, drastically reducing startup time and memory usage at the cost of build complexity and some runtime optimizations.
+
+## Decision
+
+We provide GraalVM native image support as an alternative build target alongside the standard JVM distribution. This is implemented through:
+
+1. **NativeImageConfig class**: Registers reflection hints for JPA entities (`TokenMetadata`, `TokenLogo`, `MetadataReferenceNft`, etc.) and REST model classes that require runtime reflection for Jackson serialization and JPA proxying.
+
+2. **Resource hints**: Registers Flyway migration files (`db/migration/postgresql/*`, `db/store/*`) as native image resources since they are loaded at runtime.
+
+3. **Maven native profile**: Uses `paketobuildpacks/builder-jammy-tiny` for native image compilation with flags `--no-fallback` and `-H:+ReportExceptionStackTraces`.
+
+4. **Dockerfile.native**: Dedicated Dockerfile for building and running native executables.
+
+5. **CI pipeline**: The `docker-build.yaml` workflow supports a `variant` parameter (`jvm` or `native`) for building either distribution.
+
+## Consequences
+
+### Positive
+
+- **Fast startup**: Native images start in milliseconds rather than seconds, enabling faster pod scheduling and scaling.
+- **Lower memory**: Reduced heap and metaspace requirements compared to JVM mode.
+- **Deployment flexibility**: Operators can choose between JVM (better peak throughput, easier debugging) and native (faster startup, lower footprint) based on their needs.
+- **CI validation**: Building native images in CI catches reflection and resource issues early.
+
+### Negative
+
+- **Build time**: Native image compilation is significantly slower than JVM compilation (minutes vs seconds).
+- **Reflection configuration maintenance**: Every new JPA entity or REST model class must be registered in `NativeImageConfig`, creating an ongoing maintenance burden.
+- **Reduced runtime optimization**: Native images lack JIT compilation, which may result in lower peak throughput for CPU-intensive operations.
+- **Debugging difficulty**: Native executables have limited debugging support compared to JVM applications.
+
+## Alternatives Considered
+
+- **JVM-only distribution**: Simpler to maintain but loses the startup time advantage for Kubernetes deployments.
+- **CRaC (Coordinated Restore at Checkpoint)**: Provides fast startup through checkpoint/restore without AOT compilation, but requires more complex container setup and has security implications for checkpointed state.
+- **Spring Boot class data sharing (CDS)**: A lighter-weight optimization that improves startup without full AOT compilation. Could complement native images but provides less dramatic improvement.

--- a/adr/004-cip26-cip68-dual-standard.md
+++ b/adr/004-cip26-cip68-dual-standard.md
@@ -1,0 +1,54 @@
+# ADR-004: CIP-26 and CIP-68 Dual Standard Support
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The Cardano ecosystem has two complementary standards for token metadata:
+
+- **CIP-26** (Cardano Offchain Metadata): Token metadata is submitted to a centralized GitHub repository (`cardano-foundation/cardano-token-registry`) and served via a REST API. This is the original standard, widely adopted but dependent on a manual submission process.
+
+- **CIP-68** (Datum Metadata Standard): Token metadata is stored on-chain as reference NFTs. Each fungible token can have an associated reference NFT (prefix `000643b0`) whose datum contains the metadata. This is a newer, fully decentralized approach.
+
+Many tokens have metadata registered under one or both standards, and consumers need a unified interface to query metadata regardless of its source. The registry must support both standards and allow consumers to express a preference for which source takes priority.
+
+## Decision
+
+We support both CIP-26 and CIP-68 as first-class metadata sources with the following design:
+
+1. **Separate data models**: CIP-26 metadata is stored in the `metadata` table (with JSONB for extensible properties). CIP-68 metadata is stored in the `metadata_reference_nft` table with structured columns (name, description, ticker, url, decimals, logo, version, datum).
+
+2. **Separate ingestion paths**: CIP-26 data is synced from GitHub via `TokenMetadataSyncService`. CIP-68 data is indexed from the Cardano blockchain via Yaci Store and `Cip68FungibleTokenService`.
+
+3. **Query priority model**: A `QueryPriority` enum (`CIP_26`, `CIP_68`) controls which source is queried first. The default priority is configurable via `cip.query.priority=CIP_68,CIP_26` (on-chain data preferred). The V2 API allows per-request priority override.
+
+4. **CIP-68 reference NFT identification**: Reference NFTs are identified by the `000643b0` prefix in their asset name and must have a quantity of exactly 1. The `CustomUtxoStorage` filters UTXOs to store only matching reference NFTs.
+
+5. **Validation**: CIP-26 tokens are validated against the spec using the `cf-tokens-cip26` library. CIP-68 tokens are validated structurally during datum parsing.
+
+## Consequences
+
+### Positive
+
+- **Comprehensive coverage**: Consumers get metadata regardless of which standard the token issuer chose.
+- **Flexible priority**: Operators and API consumers can decide which source they trust more.
+- **Future-proof**: Adding support for additional CIP standards (e.g., CIP-25 for NFTs) follows the same pattern.
+- **Data integrity**: Separate storage prevents data model conflicts between standards with different schemas.
+
+### Negative
+
+- **Dual maintenance**: Two ingestion pipelines, two data models, and two health indicators to maintain.
+- **Consistency challenges**: The same token may have different metadata under each standard, and the API must handle conflicts gracefully.
+- **Query complexity**: The V2 API must merge results from multiple sources, adding logic to controllers and complicating testing.
+
+## Alternatives Considered
+
+- **CIP-26 only**: Simpler but ignores the growing adoption of on-chain metadata and would make the registry increasingly incomplete.
+- **CIP-68 only**: Fully decentralized but would drop support for the large existing CIP-26 registry, breaking backward compatibility for existing consumers.
+- **Unified data model**: A single table for both standards would simplify queries but would require compromising on schema design, as CIP-26 uses JSONB properties while CIP-68 has fixed datum fields.

--- a/adr/005-postgresql-jsonb-metadata.md
+++ b/adr/005-postgresql-jsonb-metadata.md
@@ -1,0 +1,51 @@
+# ADR-005: PostgreSQL with JSONB for Extensible Metadata
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+CIP-26 token metadata has a set of well-known fields (name, ticker, description, url, decimals, logo) but also supports arbitrary custom properties submitted by token issuers. These custom properties vary widely across tokens and cannot be predicted at schema design time. The storage solution must handle both structured queries on known fields and flexible storage for unknown properties.
+
+Additionally, the API needs full-text search capability across metadata fields for discovery use cases.
+
+## Decision
+
+We use PostgreSQL as the primary database with the following schema design:
+
+1. **Structured columns for well-known fields**: The `metadata` table has dedicated columns for `subject` (PK), `policy`, `name`, `ticker`, `url`, `description`, `decimals`, `updated`, and `updated_by`. These support efficient indexing and type-safe queries.
+
+2. **JSONB column for custom properties**: A `properties` column of type `JSONB` stores arbitrary token metadata properties. This allows schema-less storage while supporting GIN indexing for containment queries.
+
+3. **Full-text search**: A generated `tsvector` column combines weighted fields (name/ticker at weight 'A', description at 'B', url/updated_by at 'C') for PostgreSQL full-text search without an external search engine.
+
+4. **Composite indexes**: A multi-column B-tree index on the structured fields (`defaultfields`) and a GIN index on the `properties` column provide query performance for both access patterns.
+
+5. **Separate logo table**: Token logos (base64-encoded PNG data, up to 87,400 characters) are stored in a `logo` table with a foreign key to `metadata`, keeping the main table lean for queries that don't need logo data.
+
+## Consequences
+
+### Positive
+
+- **Schema flexibility**: New CIP-26 properties are automatically supported without schema changes, as they are stored in the JSONB column.
+- **Query performance**: Well-known fields benefit from B-tree indexes; custom properties benefit from GIN indexes. Full-text search is built into PostgreSQL without external infrastructure.
+- **Operational simplicity**: A single database engine serves all storage needs, reducing operational complexity.
+- **ACID guarantees**: PostgreSQL provides transactional consistency for metadata updates, important when syncing incremental changes from GitHub.
+
+### Negative
+
+- **PostgreSQL lock-in**: The use of JSONB, generated columns, and `tsvector` are PostgreSQL-specific features. Migration to another database would require significant rework.
+- **JSONB query limitations**: Complex queries on deeply nested JSONB structures can be slower than queries on normalized tables with proper indexes.
+- **Logo storage in SQL**: Storing large base64 strings in a relational database is not optimal. Object storage (e.g., S3) would be more efficient for large binary data, but the simplicity trade-off is acceptable given the bounded logo size.
+
+## Alternatives Considered
+
+- **MongoDB**: Native document storage would handle the schema-less properties naturally, but adds operational complexity (separate database engine) and loses PostgreSQL's relational strengths for the structured fields.
+- **Elasticsearch**: Excellent for full-text search but would introduce a second data store requiring synchronization. PostgreSQL's built-in `tsvector` is sufficient for the current use case.
+- **Fully normalized schema**: Creating a generic key-value table for custom properties would be database-agnostic but significantly more complex to query and index.
+- **H2 for production**: Used in tests, but lacks JSONB, full-text search, and the operational maturity needed for production workloads.

--- a/adr/006-flyway-database-migrations.md
+++ b/adr/006-flyway-database-migrations.md
@@ -1,0 +1,56 @@
+# ADR-006: Flyway for Database Schema Management
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry's database schema evolves over time as new features are added (CIP-68 support, sync state tracking). Schema changes must be applied reliably across development, staging, and production environments, and must support both fresh installations and upgrades from any prior version.
+
+The application also integrates Yaci Store, which brings its own database schema for blockchain indexing. Both schemas must coexist in the same database and be managed consistently.
+
+## Decision
+
+We use Flyway for database migration management with the following configuration:
+
+1. **Migration locations**: Two directories are scanned:
+   - `db/migration/postgresql/` for application-specific migrations
+   - `db/store/{vendor}/` for Yaci Store schema (vendor-specific, e.g., PostgreSQL)
+
+2. **Migration files**:
+   - `V0__metadata_server_db_init.sql`: Initial schema (metadata, logo, wallet_scam_lookup tables with indexes and full-text search)
+   - `V1__adding_support_for_cip68.sql`: CIP-68 reference NFT table
+   - `V2__add_sync_state.sql`: Off-chain sync state tracking table
+
+3. **Configuration choices**:
+   - `baseline-on-migrate=true`: Allows Flyway to adopt existing databases without a migration history
+   - `out-of-order=true`: Permits applying migrations that are numbered lower than already-applied migrations, useful when multiple branches introduce migrations concurrently
+   - `validate-migration-naming=true`: Enforces consistent naming conventions
+
+4. **Execution**: Migrations run automatically on application startup when `spring.flyway.enabled=true`.
+
+## Consequences
+
+### Positive
+
+- **Reproducible environments**: Any environment can be built from scratch by running all migrations in order.
+- **Version tracking**: Flyway's `flyway_schema_history` table provides an audit trail of applied migrations.
+- **Multi-source schema management**: A single Flyway instance manages both application and Yaci Store schemas.
+- **Safe evolution**: Each migration is a versioned SQL file, reviewable in pull requests and testable in CI.
+
+### Negative
+
+- **Startup dependency**: The application blocks on migration execution during startup, which can be slow for large migrations.
+- **Out-of-order risks**: While enabled for development convenience, out-of-order migrations can cause confusion about the expected schema state.
+- **SQL-only migrations**: Complex data transformations may be harder to express in pure SQL compared to Java-based Flyway migrations.
+
+## Alternatives Considered
+
+- **Liquibase**: More feature-rich (XML/YAML/JSON changeset formats, rollback support) but adds complexity. Flyway's SQL-first approach is simpler and aligns with the team's preference for plain SQL.
+- **JPA auto-DDL (`hibernate.ddl-auto`)**: Convenient for development but unsafe for production, as Hibernate may generate destructive schema changes. Not suitable for a production system.
+- **Manual schema management**: No migration tool, just SQL scripts applied manually. Error-prone and not reproducible.

--- a/adr/007-yaci-store-onchain-indexing.md
+++ b/adr/007-yaci-store-onchain-indexing.md
@@ -1,0 +1,54 @@
+# ADR-007: Yaci Store for On-Chain Data Indexing
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+CIP-68 token metadata is stored on the Cardano blockchain as reference NFTs. To serve this data via the REST API, the registry needs to index relevant on-chain data. This requires connecting to a Cardano node, following the chain, parsing transactions, and extracting reference NFT datums.
+
+Building a custom chain indexer from scratch would be a significant undertaking, involving chain synchronization, rollback handling, CBOR decoding, and storage management.
+
+## Decision
+
+We integrate Yaci Store 2.0.0 as an embedded blockchain indexer within the API module. Yaci Store is a Cardano mini-indexer framework that provides:
+
+1. **Chain synchronization**: Connects to a Cardano node (default: `backbone.mainnet.cardanofoundation.org:3001`) and follows the chain from a configurable start point (slot 65836843, the CIP-68 creation slot).
+
+2. **Custom UTXO storage**: We extend `UtxoStorageImpl` with `CustomUtxoStorage` to filter and store only CIP-68 reference NFTs (identified by the `000643b0` asset name prefix with quantity = 1), reducing storage requirements.
+
+3. **CIP-68 datum parsing**: `Cip68FungibleTokenService` extracts structured metadata (name, description, ticker, url, decimals, logo, version) from reference NFT datums.
+
+4. **Auto-recovery**: Yaci Store's admin module provides automatic recovery from sync failures.
+
+5. **Health monitoring**: `OnchainSyncStatusService` tracks sync progress as a percentage by comparing current slot against the network tip, with smart refresh intervals (15 minutes during initial sync, 1 minute when near-synced).
+
+6. **Epoch calculation**: Configured with a 14,400-second interval (4 hours) for epoch boundary calculations.
+
+## Consequences
+
+### Positive
+
+- **No separate indexer**: The blockchain indexer runs within the API process, eliminating the need for a separate indexer service and its operational overhead.
+- **Selective indexing**: Custom UTXO storage ensures only relevant data (CIP-68 reference NFTs) is persisted, keeping the database lean.
+- **Real-time updates**: On-chain metadata changes are reflected in the API as soon as the chain sync catches up.
+- **Framework support**: Yaci Store handles chain following, rollback management, and CBOR decoding, letting us focus on CIP-68 business logic.
+
+### Negative
+
+- **Startup time**: Initial chain sync from the CIP-68 creation slot takes significant time, during which CIP-68 data is unavailable. The startup health probe and sync progress indicator mitigate this from an operational perspective.
+- **Process coupling**: The indexer runs in the same process as the API. A crash in chain sync affects API availability, and vice versa.
+- **Yaci Store dependency**: Tightly coupled to Yaci Store's API and data model. Major Yaci Store upgrades may require significant adaptation.
+- **Resource consumption**: Chain synchronization consumes CPU and network bandwidth, which may compete with API request handling.
+
+## Alternatives Considered
+
+- **Blockfrost API**: Query on-chain data via Blockfrost's hosted API. Simpler to integrate but introduces a third-party dependency, API rate limits, and latency. Not suitable for real-time metadata serving.
+- **DB Sync**: Use Cardano's full-chain PostgreSQL indexer. Provides comprehensive data but requires running a full Cardano node and DB Sync instance, which is operationally heavy for the limited data subset we need.
+- **Separate indexer service**: Run Yaci Store as a standalone process writing to a shared database. Better isolation but adds deployment and monitoring complexity.
+- **Ogmios / Kupo**: Lightweight chain followers that could provide similar data. Less integrated with the Spring Boot ecosystem than Yaci Store.

--- a/adr/008-jgit-git-operations.md
+++ b/adr/008-jgit-git-operations.md
@@ -1,0 +1,51 @@
+# ADR-008: JGit for Git Operations
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry synchronizes CIP-26 token metadata from the `cardano-foundation/cardano-token-registry` GitHub repository. This requires Git operations: cloning the repository, pulling updates, computing diffs to identify changed files, and extracting commit hashes for incremental sync tracking.
+
+The original implementation used shell commands (`git clone`, `git pull`, `git diff`, etc.) executed via `Runtime.exec()` or `ProcessBuilder`. This approach had several problems:
+
+- **Shell injection risk**: Constructing shell commands with user-configurable parameters (organization name, project name) could allow command injection if inputs were not properly sanitized.
+- **Platform dependency**: Shell commands behave differently across operating systems, making the application harder to test and deploy on non-Linux platforms.
+- **Error handling**: Parsing stdout/stderr from shell commands for error detection is fragile and error-prone.
+
+## Decision
+
+We replaced all shell-based Git operations with JGit 7.1.0, a pure Java implementation of the Git protocol. The `GitService` class uses JGit for:
+
+- **Clone**: `Git.cloneRepository()` to clone the token registry repository to a configurable temporary directory.
+- **Pull with rebase**: `git.pull().setRebase(true)` to update the local clone with upstream changes.
+- **Diff**: `DiffCommand` with `DiffEntry` to identify files changed between two commits, enabling incremental sync.
+- **Commit hash extraction**: `Repository.resolve("HEAD")` to get the current HEAD commit hash for sync state tracking.
+- **Resource cleanup**: `@PreDestroy` lifecycle hook ensures Git resources are properly closed on application shutdown.
+
+## Consequences
+
+### Positive
+
+- **Security**: Eliminates shell injection vectors entirely. No user input is ever passed to a shell.
+- **Cross-platform**: Works identically on Linux, macOS, and Windows without requiring Git to be installed.
+- **Type safety**: JGit provides a Java API with proper exceptions, return types, and null safety, replacing fragile string parsing.
+- **Testability**: JGit operations can be mocked in unit tests without needing a real Git binary or shell.
+- **Resource management**: JGit's `Repository` and `Git` objects implement `Closeable`, integrating naturally with Java resource management.
+
+### Negative
+
+- **Dependency size**: JGit adds a non-trivial dependency to the classpath (~3MB), though this is negligible in a containerized deployment.
+- **API complexity**: JGit's API is lower-level than shell commands for some operations, requiring more code for equivalent functionality.
+- **Feature parity**: Some advanced Git features may not be available or may work differently in JGit compared to the C Git implementation.
+
+## Alternatives Considered
+
+- **Shell commands with sanitization**: Continue using shell commands but add input sanitization. Still platform-dependent and error-prone; defense-in-depth favors eliminating the attack surface entirely.
+- **GitHub REST API**: Fetch repository content via the GitHub API instead of cloning. Avoids Git entirely but introduces API rate limits, requires authentication for private repos, and makes incremental diff computation more complex.
+- **GitHub webhooks**: Push-based notification of changes. Would require exposing a webhook endpoint, introducing network security considerations. Better for latency but more complex to implement reliably.

--- a/adr/009-incremental-github-sync.md
+++ b/adr/009-incremental-github-sync.md
@@ -1,0 +1,54 @@
+# ADR-009: Incremental GitHub Sync with Commit Tracking
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The `cardano-foundation/cardano-token-registry` GitHub repository contains thousands of token metadata files. Re-processing all files on every sync cycle is wasteful, as only a small number of files typically change between syncs. The sync process needs to be efficient while remaining resilient to failures.
+
+## Decision
+
+We implement incremental synchronization using Git commit hash tracking:
+
+1. **Sync state persistence**: The `off_chain_sync_state` table stores the `last_commit_hash` (varchar 40) of the most recently completed successful sync.
+
+2. **Incremental sync flow**:
+   - On each sync cycle, the service pulls the latest changes and compares the current HEAD against the stored commit hash.
+   - JGit's `DiffCommand` computes the list of changed files between the two commits.
+   - Only changed files are processed (parsed, validated, and upserted).
+
+3. **Full sync fallback**: If no previous commit hash exists (first run) or hash determination fails, a full sync processes all files in the `mappings` directory.
+
+4. **Partial failure handling**: If any individual token fails to process (parse error, validation failure), the sync continues with remaining tokens but does not advance the commit hash. This ensures failed tokens are retried on the next cycle.
+
+5. **Scheduling**: The sync runs as a cron job with an initial delay of 1 minute and a fixed interval of 60 minutes, conditional on `token.metadata.job.enabled=true`.
+
+6. **Sync status tracking**: The service exposes sync state via an enum (`SYNC_NOT_STARTED`, `SYNC_IN_PROGRESS`, `SYNC_DONE`, `SYNC_ERROR`, `SYNC_IN_EXTRA_JOB`) consumed by health indicators and metrics.
+
+## Consequences
+
+### Positive
+
+- **Efficiency**: Only changed files are processed, reducing sync time from minutes (full scan) to seconds for typical runs.
+- **Resilience**: Failed tokens don't block the entire sync; they are retried on the next cycle via the non-advancing commit hash.
+- **Observability**: Sync status is exposed via health checks and Prometheus metrics, giving operators visibility into sync progress.
+- **Idempotent restarts**: After a crash, the application resumes from the last successfully committed hash rather than starting over.
+
+### Negative
+
+- **Stuck on failures**: If a token permanently fails validation, the commit hash never advances past that change, causing repeated retries of all changes in that range. Manual intervention may be needed.
+- **Single-row state**: The sync state is a single row, making it difficult to track per-token sync status or support parallel sync workers.
+- **Git history dependency**: Incremental sync relies on Git history being available and consistent. Force-pushes or history rewrites on the source repository could break the diff computation.
+
+## Alternatives Considered
+
+- **File modification timestamps**: Use filesystem timestamps to detect changes. Unreliable after clone/checkout operations, which reset timestamps.
+- **Content hashing**: Hash each file and compare against stored hashes. More robust than timestamps but requires scanning all files on every cycle, negating the efficiency benefit.
+- **GitHub webhooks**: Receive push notifications for real-time sync. Lower latency but requires exposing a public endpoint and handling webhook reliability (retries, deduplication).
+- **GitHub API polling**: Use the GitHub Commits API to find changed files. Avoids cloning but introduces API rate limits and external dependency.

--- a/adr/010-v2-api-query-priority.md
+++ b/adr/010-v2-api-query-priority.md
@@ -1,0 +1,55 @@
+# ADR-010: V2 API with Query Priority Model
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The original V1 API was designed exclusively for CIP-26 offchain metadata, implementing the CIP-26 specification endpoints. With the addition of CIP-68 on-chain metadata support, the API needed to serve metadata from multiple sources. However, modifying the V1 API would break backward compatibility with existing consumers who expect strict CIP-26 responses.
+
+Different consumers have different trust preferences: some prefer on-chain data (CIP-68) as the authoritative source, while others prefer the curated offchain registry (CIP-26). The API needs to support both preferences.
+
+## Decision
+
+We introduce a V2 API at `/api/v2` alongside the existing V1 API, with the following design:
+
+1. **V1 API preserved**: The original CIP-26-only endpoints remain at the base path, serving only offchain metadata. No breaking changes for existing consumers.
+
+2. **V2 API endpoints**:
+   - `GET /api/v2/subjects/{subject}` - Single subject query with optional priority, property filter, and `showCipsDetails` flag
+   - `POST /api/v2/subjects/query` - Batch query with the same options
+
+3. **Query priority model**: A `QueryPriority` enum (`CIP_26`, `CIP_68`) controls the order in which sources are queried. The default priority is configured via `cip.query.priority=CIP_68,CIP_26` (on-chain preferred). V2 API consumers can override the priority per request.
+
+4. **Required properties validation**: V2 API enforces that `name` and `description` are always included in property filters, as these are considered essential metadata fields.
+
+5. **CIP details flag**: When `showCipsDetails=true`, the response includes information about which CIP standard provided the data, enabling transparency about the data source.
+
+6. **Metrics tracking**: API queries are tagged by version (`v1`, `v2`) and CIP hits are tracked by standard (`26`, `68`) via Prometheus counters.
+
+## Consequences
+
+### Positive
+
+- **Backward compatibility**: V1 consumers are unaffected by the introduction of multi-standard support.
+- **Consumer flexibility**: V2 consumers can choose their preferred metadata source and get transparency about data provenance.
+- **Gradual migration**: Consumers can migrate from V1 to V2 at their own pace.
+- **Operational insight**: Per-version and per-CIP metrics allow operators to understand usage patterns and plan deprecation timelines.
+
+### Negative
+
+- **Dual API maintenance**: Two API versions must be maintained, tested, and documented, increasing the maintenance surface.
+- **Eventual V1 deprecation**: At some point V1 will need to be deprecated, requiring consumer coordination.
+- **Controller complexity**: V2 controllers contain merge logic for combining results from multiple CIP sources, making them harder to test and reason about.
+
+## Alternatives Considered
+
+- **Extend V1 with optional parameters**: Add CIP-68 support to V1 via query parameters. Risks breaking existing consumers who may not expect additional fields in responses.
+- **GraphQL**: A query language would naturally support flexible field selection and multi-source resolution. However, it would be a significant departure from the REST-based CIP-26 specification and ecosystem conventions.
+- **Separate endpoints per CIP**: Expose `/cip26/{subject}` and `/cip68/{subject}` independently. Simpler per-endpoint but pushes merge logic to consumers, who would need to know about and query both endpoints.
+- **Content negotiation**: Use HTTP `Accept` headers or custom headers to select CIP priority. Less discoverable than URL-based versioning and harder to test with simple tools like `curl`.

--- a/adr/011-health-check-groups-kubernetes.md
+++ b/adr/011-health-check-groups-kubernetes.md
@@ -1,0 +1,65 @@
+# ADR-011: Health Check Groups for Kubernetes Probes
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry runs in Kubernetes, which uses three types of health probes to manage pod lifecycle:
+
+- **Startup probe**: Determines when the application has finished initializing. Until this passes, liveness and readiness probes are not checked.
+- **Liveness probe**: Determines if the application is alive. If it fails, Kubernetes restarts the pod.
+- **Readiness probe**: Determines if the application can accept traffic. If it fails, the pod is removed from service endpoints.
+
+The registry has a complex startup sequence: Flyway migrations must complete, Yaci Store must connect to a Cardano node and begin receiving blocks, and the GitHub sync must run. These phases have different health semantics and must map to the correct Kubernetes probe type.
+
+## Decision
+
+We configure three Spring Boot Actuator health groups mapped to Kubernetes probe endpoints:
+
+1. **Startup group** (`/actuator/health/startup`):
+   - `StartupHealthIndicator`: Checks that Yaci Store's block fetcher is initialized and the connection to the Cardano node is alive.
+   - Purpose: Prevents liveness checks from killing the pod during the potentially long initial chain sync.
+
+2. **Liveness group** (`/actuator/health/liveness`):
+   - Spring Boot's built-in liveness state
+   - `OffchainSyncHealthIndicator`: Reports off-chain sync status
+   - `OnchainSyncHealthIndicator`: Reports on-chain sync status with sync percentage
+   - Purpose: Detects application deadlocks or unrecoverable failures.
+
+3. **Readiness group** (`/actuator/health/readiness`):
+   - Spring Boot's built-in readiness state
+   - Both sync health indicators
+   - Database health check
+   - Purpose: Only routes traffic to pods that have completed initial sync and have a healthy database connection.
+
+**Custom health indicators**:
+
+- `OnchainSyncHealthIndicator`: Reports UP (synced), OUT_OF_SERVICE (syncing with percentage), or DOWN (error/no connection). Uses `OnchainSyncStatusService` which caches the network tip with adaptive refresh intervals.
+- `OffchainSyncHealthIndicator`: Maps sync states to health: UP (done/extra job), OUT_OF_SERVICE (in progress/not started), DOWN (error).
+- `StartupHealthIndicator`: Checks Yaci Store's `BlockFetcherInitialized` and `ConnectionAlive` flags.
+
+## Consequences
+
+### Positive
+
+- **Correct pod lifecycle**: Kubernetes won't restart pods during the long initial chain sync (startup probe), won't route traffic before data is ready (readiness), and will restart genuinely stuck pods (liveness).
+- **Granular health visibility**: Each probe endpoint returns detailed status with sync percentages and component health, useful for debugging.
+- **Operational safety**: Separating startup from liveness prevents a common Kubernetes anti-pattern where slow-starting applications are killed in a restart loop.
+
+### Negative
+
+- **Configuration complexity**: Three health groups with different indicators require careful configuration and documentation.
+- **Health indicator maintenance**: Each new component or sync mechanism needs a corresponding health indicator and group assignment.
+- **Sync percentage accuracy**: The on-chain sync percentage is approximate (based on slot comparison) and may not accurately reflect actual progress due to varying block density.
+
+## Alternatives Considered
+
+- **Single health endpoint**: One `/health` endpoint for all probes. Simpler but doesn't allow Kubernetes to distinguish between "still starting" and "broken."
+- **Custom HTTP endpoints**: Implement health checks outside Spring Actuator. Loses the framework's health aggregation and auto-configuration.
+- **Sidecar health checker**: A separate container that checks application health. Adds deployment complexity without clear benefit over Actuator endpoints.

--- a/adr/012-prometheus-business-metrics.md
+++ b/adr/012-prometheus-business-metrics.md
@@ -1,0 +1,55 @@
+# ADR-012: Prometheus Metrics with Custom Business Counters
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry needs observability beyond health checks. Operators need to understand API usage patterns, monitor token coverage across CIP standards, and track sync status over time. Standard infrastructure metrics (JVM memory, HTTP request counts) are necessary but insufficient for operating a domain-specific service.
+
+## Decision
+
+We expose Prometheus-compatible metrics via Micrometer with the namespace `cftr` (CF Token Registry), combining standard infrastructure metrics with custom business counters:
+
+**Counters (monotonically increasing)**:
+- `cftr.api.queries` (tagged by `version`: v1, v2): Total API queries per version, enabling V1 deprecation planning.
+- `cftr.api.cip.hits` (tagged by `cip`: 26, 68): Which CIP standard provided the result, tracking on-chain vs off-chain adoption.
+- `cftr.api.subjects.queried`: Total subject lookups across all endpoints.
+- `cftr.api.subjects.not_found`: Subjects queried but not found in any source.
+
+**Gauges (point-in-time values)**:
+- `cftr.tokens.cip26.count`: Total CIP-26 tokens in the registry.
+- `cftr.tokens.cip68.count`: Total CIP-68 reference NFTs indexed.
+- `cftr.sync.status`: Numeric sync state (0=not_started, 1=in_progress, 2=done, 3=error, 4=external_job).
+
+**Implementation details**:
+- `RegistryMetricsService` refreshes gauge values every 30 seconds (initial delay 5 seconds).
+- `TimedAspect` bean enables `@Timed` annotation for method-level latency measurement.
+- Metrics endpoint exposed at `/actuator/prometheus` for scraping.
+- Application-level tag: `cf-token-metadata-registry`.
+
+## Consequences
+
+### Positive
+
+- **Usage visibility**: Per-version query counts inform V1 deprecation decisions. CIP hit distribution shows the value of CIP-68 support.
+- **Capacity planning**: Token count gauges and query rates help predict storage and compute requirements.
+- **Alerting**: Sync status gauge enables alerts on sync failures. Not-found rate spikes may indicate upstream issues.
+- **Standard format**: Prometheus format integrates with existing monitoring stacks (Grafana, Alertmanager) without custom tooling.
+
+### Negative
+
+- **Refresh overhead**: Gauge refresh queries the database every 30 seconds, adding minor load.
+- **Metric cardinality**: Tag-based metrics must be managed carefully. Adding high-cardinality tags (e.g., per-subject) would cause metric explosion.
+- **Counter reset on restart**: Prometheus counters reset when the application restarts. Rate-based queries handle this correctly, but raw counter values require `increase()` or `rate()` functions.
+
+## Alternatives Considered
+
+- **StatsD/Graphite**: Push-based metrics protocol. Less common in Kubernetes environments where Prometheus pull-based scraping is standard.
+- **OpenTelemetry**: Vendor-neutral observability framework covering metrics, traces, and logs. More comprehensive but adds complexity; Micrometer already provides Prometheus integration with minimal configuration.
+- **Application logs only**: Parse structured logs for metrics. Higher latency, harder to aggregate, and more expensive at scale than dedicated metrics.

--- a/adr/013-structured-logging-ecs.md
+++ b/adr/013-structured-logging-ecs.md
@@ -1,0 +1,60 @@
+# ADR-013: Structured Logging with ECS Format
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The registry runs in containerized environments where logs are collected and aggregated by centralized logging systems (e.g., ELK stack, Loki). Plain-text log messages are difficult to parse, filter, and correlate at scale. Structured logging formats enable log aggregation tools to index fields automatically, supporting efficient search and alerting.
+
+Additionally, log messages that include user-supplied data (e.g., token subject identifiers) must be sanitized to prevent log injection attacks and excessive log volume from malformed inputs.
+
+## Decision
+
+We implement a dual-output logging strategy:
+
+1. **Console output**: Human-readable text format for local development and debugging.
+   ```properties
+   logging.structured.format.console=text
+   ```
+
+2. **File output**: Elastic Common Schema (ECS) JSON format for production log aggregation.
+   ```properties
+   logging.structured.format.file=ecs
+   logging.file.name=logs/application.log
+   ```
+
+3. **Log sanitization**: A `LogSanitizer` utility sanitizes hexadecimal subject strings in log messages, preventing log injection and controlling log volume from untrusted input.
+
+4. **Logging framework**: SLF4J via Lombok `@Slf4j` annotation, backed by Logback (Spring Boot default). Log levels follow standard conventions:
+   - `INFO`: Major operations (sync start/complete, API startup)
+   - `WARN`: Recoverable issues (individual token failures, missing files)
+   - `ERROR`: Unexpected failures with exception stack traces
+   - `DEBUG/TRACE`: Minimal usage, available for troubleshooting
+
+## Consequences
+
+### Positive
+
+- **Machine-parseable**: ECS format provides structured JSON with standardized field names, enabling automatic indexing by Elasticsearch and other tools.
+- **Developer-friendly**: Text format on console keeps local development simple without requiring JSON parsing.
+- **Ecosystem compatibility**: ECS is the standard format for Elastic Stack, widely supported by log shippers (Filebeat, Fluentd) and visualization tools (Kibana).
+- **Security**: Log sanitization prevents log injection and ensures sensitive or malformed inputs don't corrupt log streams.
+
+### Negative
+
+- **Dual format maintenance**: Developers must consider how log messages render in both formats.
+- **File-based logging in containers**: Writing to a log file in a container requires volume mounts or sidecar containers for log shipping. Alternatively, the ECS format could be applied to stdout directly.
+- **ECS verbosity**: Structured JSON logs are significantly larger than plain text, increasing storage requirements.
+
+## Alternatives Considered
+
+- **JSON to stdout only**: Simpler for container environments (logs captured by container runtime), but loses the developer-friendly text format for local use.
+- **Logstash format**: Another structured format, but ECS is the newer standard and provides richer field semantics.
+- **Custom JSON format**: Full control over field names but loses compatibility with ECS-aware tools and dashboards.
+- **Log4j2**: Alternative logging backend with native JSON layout support. However, Spring Boot's Logback integration is more mature, and switching would add configuration complexity.

--- a/adr/014-release-please-versioning.md
+++ b/adr/014-release-please-versioning.md
@@ -1,0 +1,55 @@
+# ADR-014: Release-Please for Automated Versioning
+
+## Status
+
+Accepted
+
+## Date
+
+2026-03-24
+
+## Context
+
+The project follows semantic versioning and produces multiple artifacts (API JAR, Job JAR, Docker images). Manually managing version numbers, changelogs, and release tags is error-prone and creates friction in the release process. The version number must be updated consistently across the root `pom.xml` (via the `${revision}` property), the `.release-please-manifest.json`, and Docker image tags.
+
+## Decision
+
+We use Google's Release-Please GitHub Action (`google-github-actions/release-please-action@v4`) for automated release management:
+
+1. **Conventional Commits**: Developers write commit messages following the Conventional Commits specification (e.g., `feat:`, `fix:`, `chore:`). Release-Please parses these to determine version bumps.
+
+2. **Release type**: Configured as `simple` release type, appropriate for a single-version multi-module Maven project.
+
+3. **Version sources**:
+   - `.release-please-manifest.json`: Stores the current version (`{"." : "1.5.0"}`).
+   - `pom.xml`: Version updated via XPath `//project/properties/revision` as an extra file.
+
+4. **Release workflow**: On push to `main`, Release-Please either:
+   - Creates/updates a release PR with changelog and version bump, or
+   - If a release PR is merged, creates a GitHub release with tags.
+
+5. **Downstream automation**: The release event triggers Docker image builds via the `docker-build.yaml` workflow, producing tagged images (`version-jvm`, `version-native`, `latest`).
+
+6. **License**: The project uses MPL 2.0, included in release artifacts.
+
+## Consequences
+
+### Positive
+
+- **Automated changelogs**: Release notes are generated from commit messages, ensuring comprehensive and consistent documentation.
+- **Consistent versioning**: Version numbers are updated atomically across all configuration files.
+- **Low friction releases**: Merging the release PR is the only manual step; everything else is automated.
+- **Audit trail**: Every release is tied to a specific set of commits with clear categorization (features, fixes, chores).
+
+### Negative
+
+- **Commit discipline required**: Developers must follow Conventional Commits conventions. Poorly formatted commits result in inaccurate changelogs or missed version bumps.
+- **Release PR noise**: Release-Please continuously updates a release PR on every push to `main`, which can be noisy in repositories with frequent commits.
+- **Single version constraint**: All modules share the same version, which prevents independent module releases. This is acceptable given the tightly coupled nature of the modules.
+
+## Alternatives Considered
+
+- **Maven Release Plugin**: The standard Maven approach for releases. Handles version bumps and tagging but doesn't generate changelogs and requires more manual intervention.
+- **Manual versioning**: Direct edits to `pom.xml` and manual tagging. Most flexible but most error-prone, especially for coordinating version numbers across files.
+- **Semantic Release**: Similar to Release-Please but Node.js-based. Release-Please has better GitHub Actions integration and is maintained by Google.
+- **JReleaser**: Java-focused release tool with support for multiple package managers. More powerful but more complex to configure for our simple release needs.


### PR DESCRIPTION
## Summary

- Adds 15 Architecture Decision Records (ADRs) capturing key design choices in the CF Token Metadata Registry
- Includes an overview/index ADR (000) for navigation to all other ADRs
- Covers project structure, technology stack, data standards, API design, observability, and CI/CD decisions

### ADRs included

| # | Topic |
|---|-------|
| 000 | Overview & Index |
| 001 | Multi-Module Maven Structure |
| 002 | Spring Boot 3 + Virtual Threads (JDK 25) |
| 003 | GraalVM Native Image Support |
| 004 | CIP-26 / CIP-68 Dual Standard Support |
| 005 | PostgreSQL with JSONB for Metadata |
| 006 | Flyway Database Migrations |
| 007 | Yaci Store On-Chain Indexing |
| 008 | JGit for Git Operations |
| 009 | Incremental GitHub Sync |
| 010 | V2 API with Query Priority Model |
| 011 | Health Check Groups for Kubernetes |
| 012 | Prometheus Business Metrics |
| 013 | Structured Logging (ECS) |
| 014 | Release-Please Versioning |

## Test plan

- [ ] Review each ADR for accuracy against current codebase
- [ ] Verify all cross-references and links in the overview ADR

🤖 Generated with [Claude Code](https://claude.com/claude-code)