### PR TITLE
feat: add yaci-store admin UI dependency and configuration

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -147,6 +147,12 @@
             <artifactId>yaci-store-admin-spring-boot-starter</artifactId>
             <version>${version.yaci}</version>
         </dependency>
+        <!-- Admin UI -->
+        <dependency>
+            <groupId>com.bloxbean.cardano</groupId>
+            <artifactId>yaci-store-admin-ui</artifactId>
+            <version>${version.yaci}</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-docker-compose</artifactId>

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -80,3 +80,15 @@ store.blocks.epoch-calculation-interval=14400  # 14400 = 4 hours
 #Auto Recovery on Yaci-Store available on yaci-store-admin module
 store.admin.auto-recovery-enabled=true
 store.admin.health-check-interval=20
+
+#####################################
+# Admin UI Configuration
+# Admin UI can be accessed at http://ip:port/admin-ui/
+#####################################
+store.admin.ui.enabled=true
+# Enable/disable sync control operations (start/stop/restart) in Admin UI.
+# When disabled, sync control buttons are hidden and API endpoints return 403.
+# Also disabled automatically when store.read-only-mode=true
+store.admin.ui.sync-control-enabled=true
+# Header text displayed in Admin UI
+store.admin.ui.header-text="CF Token Metadata Registry Admin - Powered by Yaci Store"


### PR DESCRIPTION
## Summary
- Add `yaci-store-admin-ui` dependency to enable the Yaci Store Admin UI dashboard
- Configure Admin UI with sync control enabled and custom header text for the Token Metadata Registry
- Admin UI accessible at `/admin-ui/`
- Part of 1.5.0 release

## Test plan
- [x] Verify application starts successfully with the new dependency
- [x] Access `/admin-ui/` and confirm the UI loads with the correct header text
- [x] Verify sync control buttons are functional