### PR TITLE
fix: resolve read-only mode startup crash and Dockerfile build failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,13 @@ API_DOCKERFILE=api/Dockerfile.native docker compose up -d --build
 
 # Preprod
 docker compose --env-file .env.preprod up -d
+
+# Read-only mode (adds a second API instance with no sync, no node connection)
+docker compose --profile ro up -d
 ```
+
+> [!TIP]
+> The `ro` profile starts an additional `api-ro` container on port `18081` that serves queries from the existing database without connecting to a Cardano node or syncing metadata. Useful for testing query behavior without waiting for a full sync.
 
 To start fresh (wipe database and resync from scratch):
 

--- a/api/Dockerfile.jvm
+++ b/api/Dockerfile.jvm
@@ -1,7 +1,5 @@
 # Dockerfile used in compose to build and run project.
-FROM eclipse-temurin:25-jdk AS builder
-
-RUN apt-get update && apt-get install -y maven && apt-get clean
+FROM maven:3-eclipse-temurin-25 AS builder
 
 ADD . /app
 WORKDIR /app

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
@@ -24,6 +24,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class HealthApiController implements HealthApi {
 
     private final OffchainSyncHealthIndicator offchainSyncHealthIndicator;
+
+    /**
+     * Nullable because {@link OnchainReadinessHealthIndicator} is conditional on Yaci Store's
+     * {@code HealthService} bean, which is not registered in read-only mode
+     * ({@code store.read-only-mode=true}). When null, the legacy health endpoint reports
+     * on-chain sync as "disabled" instead of failing.
+     */
     @Nullable
     private final OnchainReadinessHealthIndicator onchainSyncHealthIndicator;
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
@@ -23,6 +23,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Slf4j
 public class HealthApiController implements HealthApi {
 
+    public static final String SYNC_STATUS = "syncStatus";
+
     private final OffchainSyncHealthIndicator offchainSyncHealthIndicator;
 
     /**
@@ -45,14 +47,14 @@ public class HealthApiController implements HealthApi {
         Health offchainHealth = offchainSyncHealthIndicator.health();
         Health onchainHealth = onchainSyncHealthIndicator != null
                 ? onchainSyncHealthIndicator.health()
-                : Health.up().withDetail("syncStatus", "On-chain sync disabled (read-only mode)").build();
+                : Health.up().withDetail(SYNC_STATUS, "On-chain sync disabled (read-only mode)").build();
 
         boolean synced = Status.UP.equals(offchainHealth.getStatus())
                 && Status.UP.equals(onchainHealth.getStatus());
 
         String syncStatus = "offchain: %s, onchain: %s".formatted(
-                offchainHealth.getDetails().get("syncStatus"),
-                onchainHealth.getDetails().get("syncStatus"));
+                offchainHealth.getDetails().get(SYNC_STATUS),
+                onchainHealth.getDetails().get(SYNC_STATUS));
 
         return new ResponseEntity<>(HealthResponse.builder()
                 .synced(synced)

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
@@ -45,7 +45,7 @@ public class HealthApiController implements HealthApi {
         Health offchainHealth = offchainSyncHealthIndicator.health();
         Health onchainHealth = onchainSyncHealthIndicator != null
                 ? onchainSyncHealthIndicator.health()
-                : Health.unknown().withDetail("syncStatus", "On-chain sync disabled").build();
+                : Health.up().withDetail("syncStatus", "On-chain sync disabled (read-only mode)").build();
 
         boolean synced = Status.UP.equals(offchainHealth.getStatus())
                 && Status.UP.equals(onchainHealth.getStatus());

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/controller/HealthApiController.java
@@ -1,6 +1,6 @@
 package org.cardanofoundation.tokenmetadata.registry.api.controller;
 
-import lombok.RequiredArgsConstructor;
+import jakarta.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 import org.cardanofoundation.tokenmetadata.registry.api.health.OffchainSyncHealthIndicator;
 import org.cardanofoundation.tokenmetadata.registry.api.health.OnchainReadinessHealthIndicator;
@@ -21,16 +21,24 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @CrossOrigin
 @RequestMapping("${openapi.metadataServer.base-path:}")
 @Slf4j
-@RequiredArgsConstructor
 public class HealthApiController implements HealthApi {
 
     private final OffchainSyncHealthIndicator offchainSyncHealthIndicator;
+    @Nullable
     private final OnchainReadinessHealthIndicator onchainSyncHealthIndicator;
+
+    public HealthApiController(OffchainSyncHealthIndicator offchainSyncHealthIndicator,
+                               @Nullable OnchainReadinessHealthIndicator onchainSyncHealthIndicator) {
+        this.offchainSyncHealthIndicator = offchainSyncHealthIndicator;
+        this.onchainSyncHealthIndicator = onchainSyncHealthIndicator;
+    }
 
     @Override
     public ResponseEntity<HealthResponse> getHealthStatus() {
         Health offchainHealth = offchainSyncHealthIndicator.health();
-        Health onchainHealth = onchainSyncHealthIndicator.health();
+        Health onchainHealth = onchainSyncHealthIndicator != null
+                ? onchainSyncHealthIndicator.health()
+                : Health.unknown().withDetail("syncStatus", "On-chain sync disabled").build();
 
         boolean synced = Status.UP.equals(offchainHealth.getStatus())
                 && Status.UP.equals(onchainHealth.getStatus());

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainConnectionHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainConnectionHealthIndicator.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.yaci.store.core.service.HealthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 /**
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Component;
  * Used by both the startup and liveness probe groups.
  */
 @Component
+@ConditionalOnBean(HealthService.class)
 @RequiredArgsConstructor
 public class OnchainConnectionHealthIndicator implements HealthIndicator {
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainConnectionHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainConnectionHealthIndicator.java
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Component;
  * Health indicator for the Cardano node connection — checks that the connection
  * is alive and blocks are being received. Does NOT check sync progress.
  * Used by both the startup and liveness probe groups.
+ *
+ * <p>Only registered when Yaci Store's {@link HealthService} bean is present. In read-only mode
+ * ({@code store.read-only-mode=true}), Yaci Store does not start its sync infrastructure and
+ * does not register {@code HealthService}, so this indicator is skipped entirely.</p>
  */
 @Component
 @ConditionalOnBean(HealthService.class)

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainReadinessHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainReadinessHealthIndicator.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.cardanofoundation.tokenmetadata.registry.api.service.OnchainSyncStatusService;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Component;
 
 /**
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Component;
  * A pod that is still catching up will not receive requests.
  */
 @Component
+@ConditionalOnBean(HealthService.class)
 @RequiredArgsConstructor
 public class OnchainReadinessHealthIndicator implements HealthIndicator {
 

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainReadinessHealthIndicator.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/health/OnchainReadinessHealthIndicator.java
@@ -13,6 +13,10 @@ import org.springframework.stereotype.Component;
  * Readiness health indicator for on-chain sync — checks that the indexer is fully synced
  * to the chain tip (100%). Used by Kubernetes readiness probe to gate traffic routing.
  * A pod that is still catching up will not receive requests.
+ *
+ * <p>Only registered when Yaci Store's {@link HealthService} bean is present. In read-only mode
+ * ({@code store.read-only-mode=true}), Yaci Store does not start its sync infrastructure and
+ * does not register {@code HealthService}, so this indicator is skipped entirely.</p>
  */
 @Component
 @ConditionalOnBean(HealthService.class)

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -18,6 +18,11 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Tracks on-chain sync progress by comparing the local cursor position against the network tip.
  * Ported and simplified from yaci-store's admin-ui SyncStatusService.
+ *
+ * <p>Only registered when Yaci Store's {@link HealthService} bean is present. In read-only mode
+ * ({@code store.read-only-mode=true}), Yaci Store does not start its sync infrastructure and
+ * does not register the beans this service depends on ({@code CursorService}, {@code ChainTipService}),
+ * so this service is skipped entirely.</p>
  */
 @Service
 @ConditionalOnBean(HealthService.class)

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/service/OnchainSyncStatusService.java
@@ -5,8 +5,10 @@ import com.bloxbean.cardano.yaci.store.common.domain.Cursor;
 import com.bloxbean.cardano.yaci.store.common.service.CursorService;
 import com.bloxbean.cardano.yaci.store.common.util.Tuple;
 import com.bloxbean.cardano.yaci.store.core.service.ChainTipService;
+import com.bloxbean.cardano.yaci.store.core.service.HealthService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -18,6 +20,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * Ported and simplified from yaci-store's admin-ui SyncStatusService.
  */
 @Service
+@ConditionalOnBean(HealthService.class)
 @RequiredArgsConstructor
 @Slf4j
 public class OnchainSyncStatusService {


### PR DESCRIPTION
## Summary

- **Dockerfile.jvm**: Switch builder stage from `eclipse-temurin:25-jdk` + `apt-get install maven` to `maven:3-eclipse-temurin-25`, fixing build failures on macOS ARM64 due to apt platform emulation issues
- **Read-only mode startup crash**: In read-only mode (`store.read-only-mode=true`), Yaci Store does not register `HealthService` bean. Added `@ConditionalOnBean(HealthService.class)` to `OnchainReadinessHealthIndicator`, `OnchainConnectionHealthIndicator`, and `OnchainSyncStatusService` so they gracefully skip registration when Yaci Store sync is disabled
- **HealthApiController**: Made `OnchainReadinessHealthIndicator` dependency `@Nullable` with fallback for read-only mode

## Test plan

- [x] `mvn compile -pl api` passes
- [x] Health indicator unit tests pass
- [x] `docker compose --profile ro up -d --build` starts without errors
- [x] `/actuator/health/readiness` returns valid response in read-only mode
- [x] Normal (non-ro) API startup still works with full health indicators