### PR TITLE
fix(native): register JGit CoreConfig enums for GraalVM reflection

### DIFF
--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
@@ -18,6 +18,7 @@ import org.cardanofoundation.tokenmetadata.registry.entity.OffChainSyncState;
 import org.cardanofoundation.tokenmetadata.registry.entity.TokenLogo;
 import org.eclipse.jgit.diff.DiffAlgorithm;
 import org.eclipse.jgit.diff.DiffConfig;
+import org.eclipse.jgit.lib.CommitConfig;
 import org.eclipse.jgit.lib.CoreConfig;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
@@ -120,7 +121,12 @@ public class NativeImageConfig {
                     // (DiffCommand, LogCommand with path filters, and anything that
                     // invokes DiffFormatter.setRepository / setReader).
                     DiffAlgorithm.SupportedAlgorithm.class,
-                    DiffConfig.RenameDetectionType.class
+                    DiffConfig.RenameDetectionType.class,
+                    // commit.* config — read by CommitConfig.<init> when Config.get(COMMIT_KEY)
+                    // materialises the section. Triggered on incremental sync via PullCommand
+                    // → RebaseCommand → CommitConfig read (commit.cleanup setting). The initial
+                    // full-sync clone doesn't hit this; only subsequent pulls.
+                    CommitConfig.CleanupMode.class
             }) {
                 reflection.registerType(enumClass,
                         INVOKE_PUBLIC_METHODS,

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
@@ -16,6 +16,8 @@ import org.cardanofoundation.tokenmetadata.registry.entity.MetadataReferenceNft;
 import org.cardanofoundation.tokenmetadata.registry.entity.MetadataReferenceNftId;
 import org.cardanofoundation.tokenmetadata.registry.entity.OffChainSyncState;
 import org.cardanofoundation.tokenmetadata.registry.entity.TokenLogo;
+import org.eclipse.jgit.diff.DiffAlgorithm;
+import org.eclipse.jgit.diff.DiffConfig;
 import org.eclipse.jgit.lib.CoreConfig;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
@@ -83,25 +85,28 @@ public class NativeImageConfig {
             hints.resources().registerPattern("db/store/mysql/.*");
             hints.resources().registerPattern("db/store/h2/.*");
 
-            // JGit CoreConfig nested enums.
+            // JGit enum-typed git config reflection.
             //
             // org.eclipse.jgit.lib.Config#getEnum reads enum-typed git config values
-            // (core.autocrlf, core.eol, core.trustlooserefstat, …) by reflectively
-            // calling enumClass.getMethod("values"). GraalVM's static reachability
-            // analysis cannot see those calls, so without explicit hints the synthetic
-            // values() method is stripped from the native image and JGit fails on
-            // CloneCommand with:
+            // (core.autocrlf, core.eol, core.trustlooserefstat, diff.algorithm,
+            // diff.renames, …) by reflectively calling enumClass.getMethod("values").
+            // GraalVM's static reachability analysis cannot see those calls, so without
+            // explicit hints the synthetic values() method is stripped from the native
+            // image and JGit fails at runtime with:
             //
             //   java.lang.IllegalArgumentException: Enumerated values of type
-            //     org.eclipse.jgit.lib.CoreConfig$<EnumName> not available
+            //     org.eclipse.jgit.<pkg>$<EnumName> not available
             //   Caused by: java.lang.NoSuchMethodException:
-            //     org.eclipse.jgit.lib.CoreConfig$<EnumName>.values()
+            //     org.eclipse.jgit.<pkg>$<EnumName>.values()
             //
-            // Observed in production on JGit 7.1.0 with TrustLooseRefStat — the rest
-            // are registered preemptively because the same code path
-            // (Config.allValuesOf) covers every CoreConfig enum and a future JGit
-            // bump can add new ones quietly.
+            // This is a *class of bug* — every enum-typed git config setting on the
+            // JGit call path needs its enum registered for reflection. The enums below
+            // cover the CIP-26 offchain sync path (clone → log/diff walk over the
+            // cardano-token-registry repo). A future JGit bump can add new enum-typed
+            // config options that would surface here as the same error on a different
+            // enum class; extend the list as needed.
             for (Class<?> enumClass : new Class<?>[]{
+                    // core.* config — read during repo init + working tree setup.
                     CoreConfig.AutoCRLF.class,
                     CoreConfig.CheckStat.class,
                     CoreConfig.EOL.class,
@@ -110,7 +115,12 @@ public class NativeImageConfig {
                     CoreConfig.LogRefUpdates.class,
                     CoreConfig.SymLinks.class,
                     CoreConfig.TrustPackedRefsStat.class,
-                    CoreConfig.TrustLooseRefStat.class
+                    CoreConfig.TrustLooseRefStat.class,
+                    // diff.* config — read by DiffFormatter when walking commit history
+                    // (DiffCommand, LogCommand with path filters, and anything that
+                    // invokes DiffFormatter.setRepository / setReader).
+                    DiffAlgorithm.SupportedAlgorithm.class,
+                    DiffConfig.RenameDetectionType.class
             }) {
                 reflection.registerType(enumClass,
                         INVOKE_PUBLIC_METHODS,

--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/config/NativeImageConfig.java
@@ -16,6 +16,7 @@ import org.cardanofoundation.tokenmetadata.registry.entity.MetadataReferenceNft;
 import org.cardanofoundation.tokenmetadata.registry.entity.MetadataReferenceNftId;
 import org.cardanofoundation.tokenmetadata.registry.entity.OffChainSyncState;
 import org.cardanofoundation.tokenmetadata.registry.entity.TokenLogo;
+import org.eclipse.jgit.lib.CoreConfig;
 import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -81,6 +82,40 @@ public class NativeImageConfig {
             hints.resources().registerPattern("db/store/postgresql/.*");
             hints.resources().registerPattern("db/store/mysql/.*");
             hints.resources().registerPattern("db/store/h2/.*");
+
+            // JGit CoreConfig nested enums.
+            //
+            // org.eclipse.jgit.lib.Config#getEnum reads enum-typed git config values
+            // (core.autocrlf, core.eol, core.trustlooserefstat, …) by reflectively
+            // calling enumClass.getMethod("values"). GraalVM's static reachability
+            // analysis cannot see those calls, so without explicit hints the synthetic
+            // values() method is stripped from the native image and JGit fails on
+            // CloneCommand with:
+            //
+            //   java.lang.IllegalArgumentException: Enumerated values of type
+            //     org.eclipse.jgit.lib.CoreConfig$<EnumName> not available
+            //   Caused by: java.lang.NoSuchMethodException:
+            //     org.eclipse.jgit.lib.CoreConfig$<EnumName>.values()
+            //
+            // Observed in production on JGit 7.1.0 with TrustLooseRefStat — the rest
+            // are registered preemptively because the same code path
+            // (Config.allValuesOf) covers every CoreConfig enum and a future JGit
+            // bump can add new ones quietly.
+            for (Class<?> enumClass : new Class<?>[]{
+                    CoreConfig.AutoCRLF.class,
+                    CoreConfig.CheckStat.class,
+                    CoreConfig.EOL.class,
+                    CoreConfig.EolStreamType.class,
+                    CoreConfig.HideDotFiles.class,
+                    CoreConfig.LogRefUpdates.class,
+                    CoreConfig.SymLinks.class,
+                    CoreConfig.TrustPackedRefsStat.class,
+                    CoreConfig.TrustLooseRefStat.class
+            }) {
+                reflection.registerType(enumClass,
+                        INVOKE_PUBLIC_METHODS,
+                        DECLARED_FIELDS);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

CIP-26 GitHub sync is **fully broken on the GraalVM native image**. Every cron-triggered sync attempt hits a missing-reflection error from JGit because `Config.getEnum` looks up enum `values()` reflectively and GraalVM's static analysis strips the synthetic method. This PR registers the full set of JGit enums the CIP-26 sync path reads so clone, diff walk, and incremental pull all succeed end-to-end.

## Symptoms

Three distinct failures surfaced sequentially as each fix unblocked the next stage of the sync. All share one root cause — `Config.getEnum` reflectively calling `enumClass.getMethod("values")` — but fire from different call paths.

### 1. Repo init (`CloneCommand` / `RefDirectory.<init>`) — fixed by commit 1

```
java.lang.IllegalArgumentException: Enumerated values of type
  org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat not available
  at org.eclipse.jgit.lib.Config.allValuesOf(Config.java:430)
  at org.eclipse.jgit.lib.Config.getEnum(Config.java:417)
  at org.eclipse.jgit.internal.storage.file.RefDirectory.<init>(RefDirectory.java:229)
  at org.eclipse.jgit.internal.storage.file.FileRepository.<init>(FileRepository.java:189)
  at org.eclipse.jgit.lib.BaseRepositoryBuilder.build(BaseRepositoryBuilder.java:679)
  at org.eclipse.jgit.api.InitCommand.call(InitCommand.java:101)
  at org.eclipse.jgit.api.CloneCommand.init(CloneCommand.java:276)
  at org.eclipse.jgit.api.CloneCommand.call(CloneCommand.java:185)
  at o.c.t.r.service.TokenMetadataSyncService.synchronizeDatabase(...:57)
Caused by: java.lang.NoSuchMethodException:
  org.eclipse.jgit.lib.CoreConfig$TrustLooseRefStat.values()
```

`RefDirectory`'s constructor reads `core.trustlooserefstat`. Nothing reaches `metadata`.

### 2. Diff walk (`DiffCommand` / `DiffFormatter.setReader`) — fixed by commit 2

After the repo init hints landed, clone succeeded and the sync advanced to walking commit history. The next `Config.getEnum` call — reading `diff.algorithm` — hit the same reflection gap on a different enum:

```
java.lang.IllegalArgumentException: Enumerated values of type
  org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm not available
  at org.eclipse.jgit.lib.Config.allValuesOf(Config.java:430)
  at org.eclipse.jgit.lib.Config.getEnum(Config.java:417)
  at org.eclipse.jgit.diff.DiffFormatter.setReader(DiffFormatter.java:189)
  at org.eclipse.jgit.diff.DiffFormatter.setRepository(DiffFormatter.java:152)
  at org.eclipse.jgit.api.DiffCommand.call(DiffCommand.java:93)
Caused by: java.lang.NoSuchMethodException:
  org.eclipse.jgit.diff.DiffAlgorithm$SupportedAlgorithm.values()
```

### 3. Incremental pull (`PullCommand` → `RebaseCommand` → `CommitConfig.<init>`) — fixed by commit 3

Commits 1+2 unblocked the **initial full sync** end-to-end — clone 71 s, git history walk resolved 7927/7927 files, 7927 mappings inserted with zero failures. The next cron tick one hour later did an incremental pull — a code path the initial clone never exercised — and hit the third enum:

```
java.lang.IllegalArgumentException: Enumerated values of type
  org.eclipse.jgit.lib.CommitConfig$CleanupMode not available
  at org.eclipse.jgit.lib.Config.allValuesOf(Config.java:430)
  at org.eclipse.jgit.lib.Config.getEnum(Config.java:417)
  at org.eclipse.jgit.lib.CommitConfig.<init>(CommitConfig.java:115)
  at org.eclipse.jgit.lib.Config.get(Config.java:685)
  at org.eclipse.jgit.api.RebaseCommand.call(RebaseCommand.java:252)
  at org.eclipse.jgit.api.PullCommand.call(PullCommand.java:366)
Caused by: java.lang.NoSuchMethodException:
  org.eclipse.jgit.lib.CommitConfig$CleanupMode.values()
```

`PullCommand` delegates to `RebaseCommand`, which reads the `commit.*` section via `Config.get(COMMIT_KEY)` → `new CommitConfig(config)` → reads `commit.cleanup` via `Config.getEnum(CommitConfig$CleanupMode)`.

## Root cause

`org.eclipse.jgit.lib.Config#allValuesOf(Class<? extends Enum>)` looks up the synthetic `values()` method on the enum reflectively:

```java
Method m = enumClass.getMethod("values");
```

GraalVM's static reachability analysis can't see that call path (the enum class arrives as a `Class<?>` parameter through generic plumbing), so the auto-generated `public static values()` method is stripped from the native image. At runtime: `NoSuchMethodException`, JGit wraps it in `IllegalArgumentException`, the operation aborts.

This is **a class of bug**, not a single enum. Every enum-typed git config option on JGit's call path needs its enum registered. Three families of enums live on the CIP-26 sync path:

- **core.*** — read during repo init (`CloneCommand` → `RefDirectory`).
- **diff.*** — read by `DiffFormatter` when walking commit history.
- **commit.*** — read by `CommitConfig.<init>` on incremental pulls (`PullCommand` → `RebaseCommand`).

## Fix

Add reflection hints in `NativeImageConfig.Hints#registerHints` for every JGit enum the sync exercises:

```java
for (Class<?> enumClass : new Class<?>[]{
        // core.* config — read during repo init + working tree setup.
        CoreConfig.AutoCRLF.class,
        CoreConfig.CheckStat.class,
        CoreConfig.EOL.class,
        CoreConfig.EolStreamType.class,
        CoreConfig.HideDotFiles.class,
        CoreConfig.LogRefUpdates.class,
        CoreConfig.SymLinks.class,
        CoreConfig.TrustPackedRefsStat.class,
        CoreConfig.TrustLooseRefStat.class,
        // diff.* config — read by DiffFormatter during commit history walk.
        DiffAlgorithm.SupportedAlgorithm.class,
        DiffConfig.RenameDetectionType.class,
        // commit.* config — read by CommitConfig.<init> on incremental pulls
        // (PullCommand → RebaseCommand). Doesn't fire on the initial clone.
        CommitConfig.CleanupMode.class
}) {
    reflection.registerType(enumClass,
            INVOKE_PUBLIC_METHODS,   // makes values() callable
            DECLARED_FIELDS);         // makes the enum constants introspectable
}
```

- `INVOKE_PUBLIC_METHODS` keeps the synthetic `values()` method (and `valueOf(String)`) reachable.
- `DECLARED_FIELDS` keeps the enum constant fields.

The 12 enums are the complete set `Config.getEnum` reads on the CIP-26 sync's clone + log/diff + incremental-pull path for JGit `7.1.0.202411261347-r` (the version pinned in `pom.xml`). If a future JGit bump adds a new enum-typed config option on a code path we exercise, the same error will surface on a different enum class — remedy is to extend this list.

## Commits in this PR

1. `fix(native): register JGit CoreConfig enums for native-image reflection` — unblocks `CloneCommand` / `RefDirectory.<init>`.
2. `fix(native): extend JGit reflection hints to cover DiffFormatter path` — unblocks `DiffFormatter.setReader` / `DiffCommand`, reached only after commit 1 let the clone finish.
3. `fix(native): add CommitConfig.CleanupMode to cover PullCommand rebase path` — unblocks `CommitConfig.<init>` on incremental pulls, reached only after commit 2 let a full sync complete and the cron fire a second time.

## Verified in production

Commits 1+2: cron ran the full sync end-to-end — clone 71 s, git history walk 6921 commits / 7927 files resolved, 7927 mappings inserted with 0 failures, sync complete in 270 s. Commit 3 fixes the subsequent pull that would otherwise have failed every hour thereafter.

## Test plan

- [x] JVM tests still pass (`mvn -pl api -am test`) — no behavior change in JVM mode, only adds AOT hints.
- [x] CI builds the native image successfully.
- [x] On a native image deploy: `docker logs cf-token-metadata-registry-api-1` should show the full-sync success log (`Offchain sync complete in N ms`) on the first cron, and `No new commits since last sync` or a new incremental sync log on subsequent crons — no `IllegalArgumentException` / `NoSuchMethodException` anywhere.
- [x] `curl <host>/actuator/prometheus | grep cftr_tokens_cip26_count` should report the expected non-zero gauge.

## What's NOT in this PR

- No JVM-mode behavior change. Reflection hints are only consumed by the AOT processor / native image build.
- No JGit version bump — same `7.1.0.202411261347-r`.
- No fix for the unrelated Yaci-Store sync restart loop visible on the same deployment (separate symptom, separate root cause).
