### PR TITLE
fix(ci): provide fallback tag when cf-gha-baseline returns empty

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -66,6 +66,27 @@ jobs:
           EXTRA_TAGS="${EXTRA_TAGS//$'\n'/ }"
           EXTRA_TAGS="${EXTRA_TAGS//,/ }"
           EXTRA_TAGS="${EXTRA_TAGS//$'\t'/ }"
+
+          # Fallback for contexts where cf-gha-baseline cannot derive a
+          # BRANCH_NAME and therefore emits an empty
+          # EARTHLY_DOCKER_IMAGES_EXTRA_TAGS. This has been observed 100% of
+          # the time on `schedule`-triggered runs (the Nightly workflow),
+          # which caused every nightly docker-build job to fail at this
+          # step. Synthesise a tag from the GitHub-provided context so the
+          # build still produces a usable image.
+          if [[ -z "${EXTRA_TAGS// /}" ]]; then
+            short_sha="${GITHUB_SHA:0:7}"
+            if [[ "${GITHUB_EVENT_NAME}" == "schedule" ]]; then
+              fallback="nightly-$(date -u +%Y%m%d)-${short_sha}"
+            else
+              sanitized_ref="${GITHUB_REF_NAME:-unknown}"
+              sanitized_ref="${sanitized_ref//\//-}"
+              fallback="${sanitized_ref}-${short_sha}"
+            fi
+            echo "cf-gha-baseline returned no tags (event=${GITHUB_EVENT_NAME}); using fallback tag '${fallback}'" >&2
+            EXTRA_TAGS="${fallback}"
+          fi
+
           read -r -a parsed_extra_tags <<< "${EXTRA_TAGS}"
 
           declare -a resolved_tags
@@ -97,7 +118,10 @@ jobs:
           fi
 
           if [ ${#resolved_tags[@]} -eq 0 ]; then
-            echo "No tags provided by cf-gha-baseline output EARTHLY_DOCKER_IMAGES_EXTRA_TAGS" >&2
+            # Defence-in-depth: the fallback above should guarantee at
+            # least one resolved tag. If we still reach this point
+            # something is deeply wrong (GITHUB_SHA also unset, etc.).
+            echo "No tags could be resolved, including fallback from GitHub context" >&2
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

The **Nightly** workflow has failed every night for the last 8 runs (since 2026-04-10) with:

```
docker-build-jvm / build · Set image metadata
No tags provided by cf-gha-baseline output EARTHLY_DOCKER_IMAGES_EXTRA_TAGS
##[error]Process completed with exit code 1.
```

Both `docker-build-jvm` and `docker-build-native` fail at the same step, then `integration-test-docker-native` skips. Nothing downstream runs.

## Root cause

The [`cardano-foundation/cf-gha-workflows/actions/cf-gha-baseline`](https://github.com/cardano-foundation/cf-gha-workflows) action computes `DOCKER_*` tag outputs from a derived `BRANCH_NAME`. On `schedule`-triggered runs that derivation yields an empty string, so every downstream variable is empty:

```
BRANCH_NAME=
DOCKER_TAG=
EARTHLY_DOCKER_IMAGES_EXTRA_TAGS=
```

(Verified by reading the step output of the 2026-04-17 04:10 UTC nightly run — run ID [24547140247](https://github.com/cardano-foundation/cf-token-metadata-registry/actions/runs/24547140247).)

The existing `Set image metadata` step parsed that empty value into a zero-length array and hit its `exit 1` guard, killing the job before Docker Buildx ever ran.

## Fix

Before parsing `EXTRA_TAGS`, check whether it's empty/whitespace-only and synthesise a fallback from the GitHub-provided runtime context:

- `schedule` events → `nightly-YYYYMMDD-<short-sha>` (e.g. `nightly-20260417-8ba8966`)
- other empty-baseline cases → `<sanitised-ref-name>-<short-sha>`

`GITHUB_SHA`, `GITHUB_REF_NAME`, and `GITHUB_EVENT_NAME` are always populated by the GitHub Actions runner — the fallback is reliable even when the reusable action's own ref-derivation misfires.

The existing `exit 1` guard is kept as defence-in-depth with an updated message.

## What this PR does NOT change

- **Non-nightly paths are unaffected.** Push / PR / tag-push events continue producing baseline-derived tags exactly as before — the fallback is gated on `EXTRA_TAGS` being empty, which only happens when `cf-gha-baseline` itself returns empty.
- **No docker-build logic changes** beyond the single `Set image metadata` step.
- **No upstream fix to `cf-gha-workflows`.** That would be the right long-term cleanup (fix `BRANCH_NAME` derivation for schedule events in the shared action), but lives in a different repository and is out of scope here. This PR unblocks nightly builds in the meantime.

## Test plan

- [ ] After merge: the next scheduled nightly run (03:00 UTC) succeeds through the `Set image metadata` step and progresses to `Build Docker image`.
- [ ] Alternatively, manually dispatch the Nightly workflow (`workflow_dispatch` trigger) to verify without waiting.
- [ ] Confirm the built image tag is `nightly-YYYYMMDD-<short-sha>` for the JVM variant and `nightly-YYYYMMDD-<short-sha>-native` for the native variant.
- [ ] Push to `main` after merge still produces baseline-derived tags (not the fallback), since `cf-gha-baseline` populates `BRANCH_NAME=main` correctly on push events.