### PR TITLE
chore(ci): pin yaci-devkit to 0.11.0-beta1

### DIFF
--- a/.github/actions/setup-test-infra/action.yml
+++ b/.github/actions/setup-test-infra/action.yml
@@ -29,7 +29,7 @@ runs:
 
     - name: Install yaci-devkit
       shell: bash
-      run: npm install --ignore-scripts -g @bloxbean/yaci-devkit
+      run: npm install --ignore-scripts -g @bloxbean/yaci-devkit@0.11.0-beta1
 
     - name: Start Yaci DevKit
       shell: bash


### PR DESCRIPTION
## Summary
- Upgrade the GitHub runner's `yaci-devkit` install (`.github/actions/setup-test-infra`) to the latest release `v0.11.0-beta1`, pinning the npm version explicitly.
- No other changes needed: the on-disk genesis path (`\$HOME/.yaci-cli/local-clusters/default/node/genesis/{byron,shelley,alonzo,conway}-genesis.json`) is unchanged in `0.11.0-beta1`, and yaci-store exposes no REST endpoint for genesis files — they remain filesystem-only inputs to the API via `STORE_CARDANO_*_GENESIS_FILE` env vars.

## Notes
- One relevant breaking change in `0.11.0-beta1`: node config switched `configuration.yaml` → `configuration.json`. Genesis paths inside still resolve correctly, so no action required on our side.

## Test plan
- [x] CI integration-tests workflow green on this branch (jar mode + docker mode both consume the pinned devkit)
- [x] Verify `yaci-devkit up --enable-yaci-store` still produces genesis files at the expected path on the runner