### PR TITLE
fix(sync): skip registry files whose filename does not match inner subject

### DIFF
--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
@@ -118,12 +118,39 @@ public class TokenMetadataSyncService {
         int processed = 0;
         int inserted = 0;
         int skipped = 0;
+        int skippedFilenameMismatch = 0;
 
         for (File mappingFile : filesToProcess) {
             processed++;
             Optional<Mapping> mapping = tokenMappingService.parseMappings(mappingFile);
             if (mapping.isEmpty()) {
                 skipped++;
+                continue;
+            }
+
+            // Filename-vs-inner-subject filter: in the upstream cardano-token-registry
+            // and the testnet metadata-registry-testnet, the canonical file for a
+            // token is named after its subject. A non-trivial fraction of files
+            // (~90% on the testnet registry) have a filename that does not match
+            // the inner `subject` field — typos, spam, or duplicates that share an
+            // inner subject with a legitimate entry. Indexing them all means the
+            // same DB row is upserted in File.listFiles() iteration order, which
+            // is filesystem-dependent. The "winner" for such a token then varies
+            // run-to-run and across deployments.
+            //
+            // Concrete example caught in QA: subject baa836fef0... had three files
+            // (baa.../caa.../daa...). yaci-store and CF picked different ones,
+            // returning different name/desc/url for the SAME on-chain token.
+            //
+            // Skipping mismatches gives a deterministic outcome: at most one file
+            // per subject (filenames are unique), and the one we keep is the one
+            // whose filename equals the registered subject — i.e. the canonical
+            // entry per the registry's naming convention.
+            String filenameSubject = stripJsonExtension(mappingFile.getName());
+            if (!filenameSubject.equals(mapping.get().subject())) {
+                log.warn("Skipping '{}': filename does not match inner subject '{}'",
+                        mappingFile.getName(), mapping.get().subject());
+                skippedFilenameMismatch++;
                 continue;
             }
 
@@ -149,14 +176,20 @@ public class TokenMetadataSyncService {
             }
 
             if (processed % 500 == 0) {
-                log.info("Processing mappings: {}/{} done ({} inserted, {} skipped)",
-                        processed, total, inserted, skipped);
+                log.info("Processing mappings: {}/{} done ({} inserted, {} skipped, {} filename-mismatch)",
+                        processed, total, inserted, skipped, skippedFilenameMismatch);
             }
         }
 
-        log.info("Mapping processing complete: {}/{} processed, {} inserted, {} skipped, failures={}",
-                processed, total, inserted, skipped, failures.get());
+        log.info("Mapping processing complete: {}/{} processed, {} inserted, {} skipped, {} filename-mismatch, failures={}",
+                processed, total, inserted, skipped, skippedFilenameMismatch, failures.get());
         return failures.get();
+    }
+
+    private static String stripJsonExtension(String fileName) {
+        return fileName.endsWith(".json")
+                ? fileName.substring(0, fileName.length() - ".json".length())
+                : fileName;
     }
 
     private List<File> resolveFilesToProcess(String lastHash, Optional<String> newHashOpt, Path repoPath) {

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncServiceTest.java
@@ -163,5 +163,54 @@ class TokenMetadataSyncServiceTest {
             verify(syncStateRepository, never()).save(any());
             assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
         }
+
+        @Test
+        void skipsFile_whenFilenameDoesNotMatchInnerSubject() {
+            // Regression: the cardano-token-registry / metadata-registry-testnet
+            // repos contain files whose JSON `subject` field does not equal the
+            // filename. Indexing them all upserts the same DB row in arbitrary
+            // File.listFiles() order, so the same on-chain token gets a different
+            // name/description/url depending on which mismatched file came last.
+            //
+            // Real example: subject baa836fef0... has three files in the testnet
+            // registry — baa.../caa.../daa... — each with different content.
+            //
+            // We accept only the canonical (filename == inner subject) entry so
+            // each subject deterministically maps to exactly one file (filenames
+            // are unique within a directory).
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.of(new OffChainSyncState(oldHash)));
+            Path mockRepoPath = mock(Path.class);
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.of(mockRepoPath));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(newHash));
+
+            // legit.json claims to be the canonical entry for "legit" — accepted.
+            File legitFile = mock(File.class);
+            when(legitFile.getName()).thenReturn("legit.json");
+            Path legitPath = mock(Path.class);
+            when(legitPath.toFile()).thenReturn(legitFile);
+
+            // garbage.json *also* claims subject "legit" but its filename is "garbage" — mismatched, must be skipped.
+            File garbageFile = mock(File.class);
+            when(garbageFile.getName()).thenReturn("garbage.json");
+            Path garbagePath = mock(Path.class);
+            when(garbagePath.toFile()).thenReturn(garbageFile);
+
+            when(gitService.getChangedFiles(oldHash, newHash)).thenReturn(List.of(legitPath, garbagePath));
+            when(gitService.getAllMappingDetails(any())).thenReturn(Map.of(
+                    "legit.json", new MappingUpdateDetails("author", LocalDateTime.now()),
+                    "garbage.json", new MappingUpdateDetails("author", LocalDateTime.now())));
+            when(tokenMappingService.parseMappings(legitFile))
+                    .thenReturn(Optional.of(new Mapping("legit", null, null, null, null, null, null, null)));
+            when(tokenMappingService.parseMappings(garbageFile))
+                    .thenReturn(Optional.of(new Mapping("legit", null, null, null, null, null, null, null)));
+            when(tokenMetadataService.insertMapping(any(), any(), any())).thenReturn(true);
+
+            tokenMetadataSyncService.synchronizeDatabase();
+
+            // Only one insert: from legit.json. garbage.json is filtered before reaching insertMapping.
+            verify(tokenMetadataService, times(1)).insertMapping(any(), any(), any());
+            verify(syncStateRepository).save(any(OffChainSyncState.class));
+            assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
+        }
     }
 }


### PR DESCRIPTION
## Summary

The CIP-26 sync indexes every file under `mappings/` from the configured
GitHub registry. When the registry happens to contain multiple files
that claim the same inner `subject` value (with different content), the
sync upserts the same DB row for each one in `File.listFiles()`
iteration order — which is filesystem-dependent. The surviving content
for those subjects becomes non-deterministic across re-syncs and
deployments.

This PR adds a one-line check: after parsing each file, compare the
filename (sans `.json`) to the inner `subject`. If they differ, log a
WARN and skip. Filenames are unique within a directory, so after the
filter at most one file per subject survives, and the survivor is the
file whose name equals its registered subject — the registry's
documented naming convention.

## Scope across networks

Numbers from this exact instant on both upstream registries:

| Network | Files | filename ≠ subject | Subjects with >1 file | Worst case |
|---|---|---|---|---|
| **Mainnet** (`cardano-foundation/cardano-token-registry`) | 7,929 | 0 (0.0%) | 0 | n/a |
| **Preprod** (`input-output-hk/metadata-registry-testnet`) | 5,526 | 5,008 (90.6%) | 3 | 5,005 files all claiming subject `01fb761b09aec85a...de6cb95` |

So this PR:

- **No behavior change on mainnet today.** The mainnet registry is impeccably curated — every filename matches its inner subject. The new filter is dormant.
- **Behavior change on preprod for 3 subjects today.** Those are the only ones with competing files; everything else is unaffected.
- **Latent bug fix for both networks going forward.** The current code is silently non-deterministic on any future collision (spam attack, honest typo in a contributor PR). After this fix the behavior is deterministic and operators see a clear log line for every skipped file.

## Concrete example (preprod)

Subject `baa836fef09cb35e180fce4b55ded152907af1e2c840ed5218776f2f` had
three files in the upstream repo:

| Filename | filename matches? | Content |
|---|---|---|
| `baa836fef0...` | ✓ | `desc='Bad Fantasy Coin'`, `url='https://bcoin.com'` |
| `caa836fef0...` | ✗ | `desc='Fantasy Coin'`, `url='https://bcoin.co.uk'` |
| `daa836fef0...` | ✗ | `desc='New Fantasy Coin'`, `url='https://bcoin.com'` |

All three are syntactically valid CIP-26 entries claiming the same
on-chain subject. Today the V2 API returns whichever file the
filesystem returned last in `listFiles()` — different content across
deployments. With this fix, only `baa836fef0...` (canonical match) is
indexed.

The same shape applies to two other preprod subjects: `7755534454`
(`wUSDT` vs the mislabeled `wSHIBA` file), and the 5,005-file
`01fb761b...de6cb95` cluster.

## What stays the same

- Mainnet: 7,929 files all match → 7,929 files still indexed → no
  data-shape change in production.
- Spec compliance: only files violating the implicit
  filename-equals-subject convention are skipped. Files that are valid
  CIP-26 *and* canonically named pass through unchanged.
- Cursor-advance semantics, retry logic, all other sync paths: untouched.

## Trade-offs

For the rare case where the registry has **only** mismatched files for
a subject (no canonical entry at all), that subject is now lost. In the
preprod registry there is exactly one such case — the placeholder
`mynewsubject-is-very-long-256-characters-...` — which is itself a
non-hex string that violates CIP-26's `[0-9a-f]{56,120}` subject rule
and gets rejected at validation anyway. Mainnet has zero such cases.

The selected canonical entry may differ from what the API served before
this PR for the affected preprod subjects — for `baa836fef0...` the new
behavior surfaces `Bad Fantasy Coin` / `bcoin.com` (canonical) instead
of the arbitrary `Fantasy Coin` / `bcoin.co.uk` (mismatched garbage).
Picking the canonically-named file is the more defensible default.

## Test plan

- [x] Existing `TokenMetadataSyncServiceTest` cases still pass (they
      already use matching subject/filename, so they're unaffected by
      the new filter)
- [x] New `skipsFile_whenFilenameDoesNotMatchInnerSubject` test —
      sets up two files both claiming inner subject `legit`, only the
      `legit.json` one reaches `insertMapping`
- [x] `mvn -pl common test` → 77 tests, 0 failures
- [ ] Verify on a preprod re-sync that the completion log line shows
      `filename-mismatch=5008` and that the diff vs the previous DB
      state matches the cleanup hypothesis
- [ ] Mainnet re-sync should show `filename-mismatch=0`