### PR TITLE
fix(metadata): base64-encode logo in V2 metadata block (was hex)

### DIFF
--- a/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/model/v2/Metadata.java
+++ b/api/src/main/java/org/cardanofoundation/tokenmetadata/registry/api/model/v2/Metadata.java
@@ -1,10 +1,11 @@
 package org.cardanofoundation.tokenmetadata.registry.api.model.v2;
 
-import com.bloxbean.cardano.client.util.HexUtil;
 import lombok.Builder;
 import org.cardanofoundation.tokenmetadata.registry.api.model.QueryPriority;
 import org.cardanofoundation.tokenmetadata.registry.api.model.cip68.FungibleTokenMetadata;
 import org.cardanofoundation.tokenmetadata.registry.api.model.rest.TokenMetadata;
+
+import java.util.Base64;
 
 @Builder(toBuilder = true)
 public record Metadata(StringProperty name, StringProperty description, StringProperty ticker, LongProperty decimals,
@@ -33,7 +34,10 @@ public record Metadata(StringProperty name, StringProperty description, StringPr
         StringProperty description = metadata.getDescription() != null ? new StringProperty(metadata.getDescription().getValue(), QueryPriority.CIP_26.name()) : null;
         StringProperty ticker = metadata.getTicker() != null ? new StringProperty(metadata.getTicker().getValue(), QueryPriority.CIP_26.name()) : null;
         LongProperty decimals = metadata.getDecimals() != null ? new LongProperty(metadata.getDecimals().getValue().longValue(), QueryPriority.CIP_26.name()) : null;
-        StringProperty logo = metadata.getLogo() != null ? new StringProperty(HexUtil.encodeHexString(metadata.getLogo().getValue()), QueryPriority.CIP_26.name()) : null;
+        // CIP-26 spec: logo bytes must be base64-encoded. Was previously hex-encoded here, which
+        // diverged from both the spec and from this same response's standards.cip26.logo block
+        // (Jackson's default byte[] serialization is base64). Standardise on base64 everywhere.
+        StringProperty logo = metadata.getLogo() != null ? new StringProperty(Base64.getEncoder().encodeToString(metadata.getLogo().getValue()), QueryPriority.CIP_26.name()) : null;
         StringProperty url = metadata.getUrl() != null ? new StringProperty(metadata.getUrl().getValue(), QueryPriority.CIP_26.name()) : null;
 
         return new Metadata(name, description, ticker, decimals, logo, url, null);

--- a/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/model/v2/MetadataTest.java
+++ b/api/src/test/java/org/cardanofoundation/tokenmetadata/registry/api/model/v2/MetadataTest.java
@@ -2,10 +2,13 @@ package org.cardanofoundation.tokenmetadata.registry.api.model.v2;
 
 import org.cardanofoundation.tokenmetadata.registry.api.model.cip68.FungibleTokenMetadata;
 import org.cardanofoundation.tokenmetadata.registry.api.model.rest.TokenMetadata;
+import org.cardanofoundation.tokenmetadata.registry.api.model.rest.wellknownproperties.LogoProperty;
 import org.cardanofoundation.tokenmetadata.registry.api.model.rest.wellknownproperties.NameProperty;
 import org.cardanofoundation.tokenmetadata.registry.api.model.rest.wellknownproperties.TickerProperty;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import java.util.Base64;
 
 import static org.cardanofoundation.tokenmetadata.registry.api.model.QueryPriority.CIP_26;
 import static org.cardanofoundation.tokenmetadata.registry.api.model.QueryPriority.CIP_68;
@@ -57,5 +60,26 @@ class MetadataTest {
 
     }
 
+    @Test
+    void logoFromCip26IsBase64Encoded() {
+        // CIP-26 spec mandates base64 logos. Same shape as standards.cip26.logo (which is the
+        // raw byte[] property — Jackson default-serializes that as base64). The flat metadata
+        // block was historically hex-encoding the bytes here, which diverged from both the
+        // spec and the standards block in the same response. Lock in base64.
+        NameProperty nameProperty = new NameProperty();
+        nameProperty.setValue("name");
+
+        byte[] logoBytes = new byte[]{(byte) 0x89, 'P', 'N', 'G', '\r', '\n', 0x1A, '\n'}; // PNG magic
+        LogoProperty logoProperty = new LogoProperty();
+        logoProperty.setValue(logoBytes);
+
+        Metadata actual = Metadata.from(TokenMetadata.builder()
+                .name(nameProperty)
+                .logo(logoProperty)
+                .build());
+
+        String expectedBase64 = Base64.getEncoder().encodeToString(logoBytes);
+        Assertions.assertEquals(new StringProperty(expectedBase64, CIP_26.name()), actual.logo());
+    }
 
 }


### PR DESCRIPTION
## Summary

CIP-26 mandates base64-encoded logos, but V2 responses were inconsistent:

- `subject.metadata.logo.value` (flat merged block) → **hex**
- `subject.standards.cip26.logo.value` (envelope, when `show_cips_details=true`) → **base64**

Same response, same logo bytes, two encodings — and the flat block was the spec-noncompliant one. The hex-encoding was happening at `Metadata.from(TokenMetadata)` line 36 via `HexUtil.encodeHexString(...)`, while the standards block reached the wire via Jackson's default `byte[]` serialisation (which is base64).

## Change

One-liner in `api/.../v2/Metadata.java`: replace `HexUtil.encodeHexString(...)` with `Base64.getEncoder().encodeToString(...)`. Drop the now-unused `HexUtil` import.

## Why this matters

- **Spec compliance** — CIP-26 § "Well-known property logo" says logo MUST be base64.
- **Internal consistency** — `metadata.logo` and `standards.cip26.logo` in the same response now agree byte-for-byte.
- **Consumer ergonomics** — clients no longer need per-server logic to decide whether to base64-decode or hex-decode the logo.

## Test plan

- [x] Added regression test `MetadataTest#logoFromCip26IsBase64Encoded` that builds a `TokenMetadata` with raw PNG-magic bytes and asserts the produced `StringProperty` value equals `Base64.getEncoder().encodeToString(...)`. Locks in the spec-compliant encoding so it can't drift back.
- [x] `./mvnw -pl api -am test` → BUILD SUCCESS, all tests pass.
- [ ] Verify on preprod: hit `/api/v2/subjects/{subject}?show_cips_details=true` and confirm `subject.metadata.logo.value == subject.standards.cip26.logo.value` byte-for-byte.