### PR TITLE
docs(readme): correct health probe descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ For the full API reference (including V1 endpoints and query parameters), see th
 |--------|------|-------------|------------------|
 | GET | `/actuator/health` | Aggregated health status with details for all indicators | — |
 | GET | `/actuator/health/startup` | Checks database connectivity and Cardano node connection | Startup |
-| GET | `/actuator/health/liveness` | Checks offchain sync status and Cardano node connection | Liveness |
-| GET | `/actuator/health/readiness` | Checks offchain sync, on-chain sync progress (100%), and database | Readiness |
+| GET | `/actuator/health/liveness` | Checks the Cardano node connection (block reception) | Liveness |
+| GET | `/actuator/health/readiness` | Checks offchain sync, on-chain sync (caught up to chain tip), and database | Readiness |
 | GET | `/actuator/info` | Application info | — |
 | GET | `/actuator/prometheus` | Prometheus metrics (Micrometer) | — |
 | GET | `/actuator/metrics` | Micrometer metrics listing and details | — |


### PR DESCRIPTION
## Summary

Fixes two inaccuracies in the **Operational Endpoints** table that exist on `main`:

- **liveness** was described as checking *"offchain sync status and Cardano node connection."* It does **not** check offchain sync — the liveness group is `livenessState` + the Cardano node connection (block reception). Offchain (CIP-26) sync lives in the **readiness** group. → corrected to "Checks the Cardano node connection (block reception)".
- **readiness** *"on-chain sync progress (100%)"* → "on-chain sync (caught up to chain tip)". The on-chain indicator reports ready when the indexer reaches the tip, not at a fixed percentage.

Docs-only, 2 lines.

## Verification

Against `application.properties` on `main`:
- `management.endpoint.health.group.liveness.include=livenessState,onchainConnection` (no `offchainSync`)
- `management.endpoint.health.group.readiness.include=readinessState,offchainSync,onchainReadiness,db`