### PR TITLE
fix(cip113): overwrite same-slot registry-node updates (PK key,slot)

### DIFF
--- a/adr/016-cip113-programmable-tokens.md
+++ b/adr/016-cip113-programmable-tokens.md
@@ -40,7 +40,7 @@ CREATE TABLE cip113_registry_node (
     global_state_policy_id VARCHAR(56),
     next VARCHAR(64) NOT NULL,
     datum TEXT NOT NULL,
-    PRIMARY KEY (key, slot, tx_hash)
+    PRIMARY KEY (key, slot)
 );
 ```
 
@@ -66,7 +66,13 @@ The public service API (`Cip113RegistryService.findByPolicyId` / `findByPolicyId
 
 Column lengths are bounded to their protocol maxima: 28-byte policy IDs / credential hashes are `VARCHAR(56)` (56 hex chars), 32-byte transaction hashes are `VARCHAR(64)`. The `key` and `next` columns are `VARCHAR(64)` rather than `VARCHAR(56)` to accommodate the head/tail sentinels described above — do not shrink them to 56 even though real policy IDs fit. The `next` column is `NOT NULL` because every registry node — including the head and tail sentinels — must point to a next entry.
 
-The composite primary key `(key, slot, tx_hash)` allows tracking historical updates. Queries use `ORDER BY slot DESC LIMIT 1` to get the latest entry for a given key.
+The composite primary key is `(key, slot)` — deliberately **not** `(key, slot, tx_hash)`. This is a current-state registry, not a per-transaction audit trail: queries use `ORDER BY slot DESC LIMIT 1` to get the latest entry for a given key, and per-slot rows are enough to keep rollback (`WHERE slot > ?`) and point-in-time-by-slot correct.
+
+Keeping `tx_hash` out of the key means two updates to the same registry node **within the same slot** — possible via intra-block transaction chaining (a second tx in the same block spending the first's registry-node output) — collapse to a single row through `saveAll`'s merge, resolving last-writer-wins in block/tx processing order. Had `tx_hash` stayed in the key, that case would produce two rows tied at the same `(key, slot)`; the batch read path `findLatestByKeys` (`ROW_NUMBER() OVER (PARTITION BY key ORDER BY slot DESC)`) would then pick one **non-deterministically** (no in-block ordering column to tie-break on), and `Cip113RegistryService.findByPolicyIds` collecting into a `Collectors.toMap` keyed by `key` could surface stale state. `(key, slot)` guarantees exactly one row per `(key, slot)`, so each key resolves to a single deterministic latest row and the batch lookup can never collide.
+
+This mirrors `metadata_reference_nft`, whose key is `(policy_id, asset_name, slot)` for the same reason. `tx_hash` is retained as a provenance-only column.
+
+> Note on divergence from yaci-store's `assets-ext`: yaci-store resolves the identical concern by *preserving* full history — it adds a non-key `tx_index` ordering column and keeps `tx_hash` in the key (`(key, slot, tx_hash)`), because yaci-store's design guideline is to never do in-place updates. cf-token-metadata-registry has no such guideline and only ever serves current resolved state, so it takes the simpler overwrite-same-slot route here.
 
 **Field nullability:**
 

--- a/api/src/main/resources/db/migration/postgresql/V3__adding_support_for_cip113.sql
+++ b/api/src/main/resources/db/migration/postgresql/V3__adding_support_for_cip113.sql
@@ -22,6 +22,7 @@ CREATE TABLE cip113_registry_node (
     key VARCHAR(64) NOT NULL,
     slot BIGINT NOT NULL,
     -- Cardano transaction hash: exactly 32 bytes = 64 hex chars. Protocol-bounded.
+    -- Provenance only — NOT part of the primary key (see PRIMARY KEY note below).
     tx_hash VARCHAR(64) NOT NULL,
     -- Aiken Credential inner hash (either VerificationKey or Script): 28 bytes = 56 hex.
     -- The constructor variant (VKey vs Script) is currently NOT preserved — if that
@@ -35,7 +36,13 @@ CREATE TABLE cip113_registry_node (
     next VARCHAR(64) NOT NULL,
     -- Full CBOR hex of the inline datum. Variable length.
     datum TEXT NOT NULL,
-    PRIMARY KEY (key, slot, tx_hash)
+    -- Current-state model: PK is (key, slot), NOT (key, slot, tx_hash). Two updates to the same
+    -- registry node in the same slot (intra-block tx chaining) collapse to a single row via the
+    -- application's saveAll merge (last-writer-wins in block/tx order). This mirrors
+    -- metadata_reference_nft's (policy_id, asset_name, slot) key and guarantees findLatestByKeys
+    -- resolves each key to exactly one row, so the batch lookup never hits a duplicate-key crash.
+    -- We deliberately do NOT retain full intra-slot history — this is a current-state registry.
+    PRIMARY KEY (key, slot)
 );
 
 -- Cip113RegistryNodeRepository.deleteBySlotGreaterThan(Long)

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/entity/Cip113RegistryNode.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/entity/Cip113RegistryNode.java
@@ -16,7 +16,7 @@ import jakarta.annotation.Nullable;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-// Business-key equals/hashCode: all three PK components are app-assigned and non-null at
+// Business-key equals/hashCode: both PK components (key, slot) are app-assigned and non-null at
 // construction, so they're stable across the transient → managed → detached lifecycle.
 // Lombok's generated equals uses `instanceof` (proxy-safe for lazy-loaded associations).
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
@@ -80,10 +80,20 @@ public class Cip113RegistryNode {
     @EqualsAndHashCode.Include
     private Long slot;
 
-    /** Cardano transaction hash: exactly 32 bytes = 64 hex chars. Protocol-bounded. */
-    @Id
+    /**
+     * Cardano transaction hash of the output that produced this registry-node state:
+     * exactly 32 bytes = 64 hex chars. Protocol-bounded.
+     *
+     * <p><b>Not part of the primary key.</b> The PK is {@code (key, slot)} so that two updates to
+     * the same registry node within the same slot (intra-block transaction chaining) collapse to a
+     * single row via {@code saveAll}'s merge — last-writer-wins in block/tx processing order. This
+     * "current-state, overwrite same-slot" model matches {@code metadata_reference_nft}
+     * ({@code (policy_id, asset_name, slot)}) and guarantees {@code findLatestByKeys} resolves each
+     * key to exactly one row, so the batch lookup in {@code Cip113RegistryService.findByPolicyIds}
+     * can never hit a {@code Collectors.toMap} duplicate-key crash. {@code tx_hash} is retained as a
+     * provenance column only.
+     */
     @Column(name = "tx_hash", length = 64, nullable = false)
-    @EqualsAndHashCode.Include
     private String txHash;
 
     /** Aiken {@code Credential} inner hash (28-byte vkey or script hash, 56 hex chars). */

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/entity/Cip113RegistryNodeId.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/entity/Cip113RegistryNodeId.java
@@ -12,6 +12,5 @@ public class Cip113RegistryNodeId {
 
     private String key;
     private Long slot;
-    private String txHash;
 
 }

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/repository/Cip113RegistryNodeRepositoryIT.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/repository/Cip113RegistryNodeRepositoryIT.java
@@ -1,0 +1,141 @@
+package org.cardanofoundation.tokenmetadata.registry.repository;
+
+import org.cardanofoundation.tokenmetadata.registry.config.RepositoryTestConfig;
+import org.cardanofoundation.tokenmetadata.registry.entity.Cip113RegistryNode;
+import org.junit.jupiter.api.Test;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+/**
+ * Integration tests for {@link Cip113RegistryNodeRepository}, focused on the current-state /
+ * overwrite-same-slot data model (PK {@code (key, slot)}, tx_hash provenance-only).
+ *
+ * <p>These lock in the behaviour that fixes the same-slot / intra-block-chaining defect flagged in
+ * yaci-store PR #870: two updates to the same registry node in the same slot must collapse to a
+ * single deterministic row rather than producing duplicates that crash the batch lookup.
+ */
+@SpringBootTest(classes = RepositoryTestConfig.class)
+@Transactional
+@ActiveProfiles("integration-test")
+// The `key` column mirrors the on-chain Aiken datum field name; it is a reserved word in H2 but
+// not in PostgreSQL (the production target, and what the V3 migration is written for). H2 is only
+// used here as an in-memory test DB, so NON_KEYWORDS=KEY lets the unquoted `key` in the entity and
+// the ROW_NUMBER() native query parse — without quoting `key` in a way that would diverge from PG.
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:cip113regnode;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;NON_KEYWORDS=KEY",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.jpa.database-platform=org.hibernate.dialect.H2Dialect",
+        "spring.flyway.enabled=false"
+})
+class Cip113RegistryNodeRepositoryIT {
+
+    // 56-hex (28-byte) policy IDs — the real-registration form of the `key` column.
+    private static final String KEY_A = "deadbeefcafebabedeadbeefcafebabedeadbeefcafebabedeadbeef0";
+    private static final String KEY_B = "aabbccdd11223344aabbccdd11223344aabbccdd11223344aabbccdd0";
+
+    // 64-hex (32-byte) transaction hashes.
+    private static final String TX_1 = "1111111111111111111111111111111111111111111111111111111111111111";
+    private static final String TX_2 = "2222222222222222222222222222222222222222222222222222222222222222";
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Autowired
+    private Cip113RegistryNodeRepository repository;
+
+    @Test
+    void sameSlotUpdate_collapsesToSingleRow_lastWriterWins() {
+        // Two updates to the SAME registry node in the SAME slot (intra-block tx chaining),
+        // differing only in tx_hash and the transfer-logic script. Processed in block/tx order.
+        Cip113RegistryNode first = node(KEY_A, 100L, TX_1, "1111111111111111111111111111111111111111111111111111111a");
+        Cip113RegistryNode second = node(KEY_A, 100L, TX_2, "2222222222222222222222222222222222222222222222222222222b");
+
+        repository.saveAll(List.of(first, second));
+        entityManager.flush();
+        entityManager.clear();
+
+        // PK (key, slot) collapses the two into one row — no duplicate, no constraint violation.
+        List<Cip113RegistryNode> all = repository.findAll();
+        assertThat(all).hasSize(1);
+        // Last writer wins: the surviving row is the later tx in processing order.
+        assertThat(all.getFirst().getTransferLogicScript())
+                .isEqualTo("2222222222222222222222222222222222222222222222222222222b");
+    }
+
+    @Test
+    void findLatestByKeys_returnsExactlyOneRowPerKey_andNeverCrashesToMap() {
+        // KEY_A has history across two slots plus a same-slot double-update at slot 100;
+        // KEY_B has a single row. This is the exact shape that used to produce duplicate
+        // rows at MAX(slot) and blow up Cip113RegistryService.findByPolicyIds' Collectors.toMap.
+        repository.saveAll(List.of(
+                node(KEY_A, 100L, TX_1, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa1"),
+                node(KEY_A, 100L, TX_2, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa2"),
+                node(KEY_A, 200L, TX_2, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa3"),
+                node(KEY_B, 150L, TX_1, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb1")
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        List<Cip113RegistryNode> latest = repository.findLatestByKeys(List.of(KEY_A, KEY_B));
+
+        // Exactly one row per key.
+        assertThat(latest).hasSize(2);
+        // Collecting by key — mirrors Cip113RegistryService.findByPolicyIds — must not throw.
+        Map<String, Cip113RegistryNode> byKey = assertNoToMapCrash(latest);
+        // Latest-by-slot resolution.
+        assertThat(byKey.get(KEY_A).getSlot()).isEqualTo(200L);
+        assertThat(byKey.get(KEY_B).getSlot()).isEqualTo(150L);
+    }
+
+    @Test
+    void findFirstByKeyOrderBySlotDesc_returnsLatestSlot() {
+        repository.saveAll(List.of(
+                node(KEY_A, 100L, TX_1, "cccccccccccccccccccccccccccccccccccccccccccccccccccccc01"),
+                node(KEY_A, 300L, TX_2, "cccccccccccccccccccccccccccccccccccccccccccccccccccccc02")
+        ));
+        entityManager.flush();
+        entityManager.clear();
+
+        Optional<Cip113RegistryNode> result = repository.findFirstByKeyOrderBySlotDesc(KEY_A);
+
+        assertThat(result).isPresent();
+        assertThat(result.get().getSlot()).isEqualTo(300L);
+    }
+
+    private static Map<String, Cip113RegistryNode> assertNoToMapCrash(List<Cip113RegistryNode> rows) {
+        Map<String, Cip113RegistryNode>[] holder = new Map[1];
+        assertThatCode(() -> holder[0] = rows.stream()
+                .collect(Collectors.toMap(Cip113RegistryNode::getKey, r -> r)))
+                .doesNotThrowAnyException();
+        return holder[0];
+    }
+
+    private static Cip113RegistryNode node(String key, long slot, String txHash, String transferLogic) {
+        return Cip113RegistryNode.builder()
+                .key(key)
+                .slot(slot)
+                .txHash(txHash)
+                .transferLogicScript(transferLogic)
+                .thirdPartyTransferLogicScript(null)
+                .globalStatePolicyId(null)
+                .next("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+                .datum("d8799f40ff")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Backports the same-slot / intra-block-chaining defect fix that was flagged and discussed in **[bloxbean/yaci-store#870](https://github.com/bloxbean/yaci-store/pull/870)** (by `@satran004` and `@Sotatek-HuyLe3a`), targeting the `CIP-113-token` branch.

Per the agreed direction for this repo, it uses the **overwrite (last-writer-wins) approach** rather than yaci-store's history-preserving one. yaci-store keeps full per-slot history (it added a non-key `tx_index` column and kept `tx_hash` in the key) because its design guideline forbids in-place updates. `cf-token-metadata-registry` is a **current-state registry** — it only serves the latest resolved metadata — so it doesn't need that history and takes the simpler route. **The point is: we must not crash when this happens; we deliberately do not retain intra-slot history.**

## The defect

`cip113_registry_node` was keyed on `(key, slot, tx_hash)`. If the same registry node is updated **twice in the same slot** — possible via intra-block transaction chaining (a second tx in the same block spending the first's registry-node output) — two rows survive at the same `(key, slot)`.

The batch reader `Cip113RegistryNodeRepository.findLatestByKeys()` (`ROW_NUMBER() OVER (PARTITION BY key ORDER BY slot DESC)`) then has **no deterministic tie-break** within a slot (`slot` ties, `tx_hash` is a hash not a sequence), so `Cip113RegistryService.findByPolicyIds()` can surface **stale state** and — in the `slot = MAX(slot)` variant that yaci-store originally had — crash on a `Collectors.toMap` duplicate key.

## The fix

Drop `tx_hash` from the primary key → **`PRIMARY KEY (key, slot)`**. Same-slot updates now collapse via `saveAll`'s merge in block/tx processing order (last-writer-wins), guaranteeing exactly **one deterministic row per `(key, slot)`**. `tx_hash` is retained as a provenance-only column.

This mirrors `metadata_reference_nft`, which is already keyed `(policy_id, asset_name, slot)` — i.e. **CIP-68 was already overwrite-based, so no CIP-68 change is required.**

Because CIP-113 is unreleased (this branch is awaiting mainnet readiness), the `V3` init migration is edited **in place** rather than shipping an `ALTER`.

## Changes

- `Cip113RegistryNode` — remove `@Id` / `@EqualsAndHashCode.Include` from `txHash`; keep it as a provenance column with updated Javadoc.
- `Cip113RegistryNodeId` — drop `txHash`.
- `V3__adding_support_for_cip113.sql` — `PRIMARY KEY (key, slot)`.
- `adr/016-cip113-programmable-tokens.md` — document the current-state keying and the deliberate divergence from yaci-store.
- `Cip113RegistryNodeRepositoryIT` (new) — locks in same-slot collapse (last-writer-wins) and that the batch lookup returns one row per key with no `toMap` crash.

## Test plan

- [x] `common`: `Cip113RegistryNodeRepositoryIT` (3) + `MetadataReferenceNftRepositoryIT` (5) green
- [x] `api`: all CIP-113 + CIP-68 tests green (68 run, 0 failures)

> Note: the new IT points H2 at a datasource with `NON_KEYWORDS=KEY` because `key` is a reserved word in H2 (the in-memory test DB) but **not** in PostgreSQL (the production target the `V3` migration is written for). This is scoped to the test class only; production/PG is unaffected.