### PR TITLE
fix(docker): use API_EXPOSED_PORT for API healthcheck instead of AP_LOCAL_BIND_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ x-api-service-common: &api-service-common
     context: .
     dockerfile: ${API_DOCKERFILE:-api/Dockerfile.jvm}
   healthcheck: &api-healthcheck
-    test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/${API_LOCAL_BIND_PORT}'"]
+    test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/${API_EXPOSED_PORT}'"]
     interval: 30s
     timeout: 5s
     retries: 10


### PR DESCRIPTION

The healthcheck runs inside the container, where only the container-side port (API_EXPOSED_PORT) is meaningful. API_LOCAL_BIND_PORT is the host-side bind port from the host:container mapping and has no meaning inside the container's network namespace. This was masked when both variables happened to share the same value (the repo's default .env), but breaks whenever a deployer sets a custom host port, e.g. API_LOCAL_BIND_PORT=11341 with API_EXPOSED_PORT left at 8080 — the container is then reported unhealthy indefinitely even though the app is running fine.