### PR TITLE
fix(sync): propagate CIP-26 token deletions from the upstream registry

### DIFF
--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/model/ChangedMappings.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/model/ChangedMappings.java
@@ -1,0 +1,19 @@
+package org.cardanofoundation.tokenmetadata.registry.model;
+
+import java.nio.file.Path;
+import java.util.List;
+
+/**
+ * Result of diffing the mappings folder between two commits of the token registry repository.
+ *
+ * @param upsertedFiles    mapping files that were added or modified and must be (re-)indexed
+ * @param deletedFileNames file names (e.g. {@code <subject>.json}) of mapping files that were
+ *                         removed from the registry and whose metadata must be deleted locally
+ */
+public record ChangedMappings(List<Path> upsertedFiles, List<String> deletedFileNames) {
+
+    public static ChangedMappings empty() {
+        return new ChangedMappings(List.of(), List.of());
+    }
+
+}

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/repository/TokenMetadataRepository.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/repository/TokenMetadataRepository.java
@@ -3,10 +3,16 @@ package org.cardanofoundation.tokenmetadata.registry.repository;
 import org.cardanofoundation.tokenmetadata.registry.entity.TokenMetadata;
 import org.springframework.context.annotation.Profile;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 @Profile("!test")
 public interface TokenMetadataRepository extends JpaRepository<TokenMetadata, String> {
+
+    @Query("select t.subject from TokenMetadata t")
+    List<String> findAllSubjects();
 
 }

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/GitService.java
@@ -3,6 +3,7 @@ package org.cardanofoundation.tokenmetadata.registry.service;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
+import org.cardanofoundation.tokenmetadata.registry.model.ChangedMappings;
 import org.cardanofoundation.tokenmetadata.registry.model.MappingUpdateDetails;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.BranchConfig;
@@ -294,10 +295,10 @@ private boolean isGitRepo() {
         return Optional.empty();
     }
 
-    public List<Path> getChangedFiles(String fromHash, String toHash) {
+    public ChangedMappings getChangedMappings(String fromHash, String toHash) {
         if (git == null) {
             log.warn(GIT_NOT_INITIALIZED);
-            return List.of();
+            return ChangedMappings.empty();
         }
         try {
             Repository repository = git.getRepository();
@@ -307,7 +308,7 @@ private boolean isGitRepo() {
 
             if (oldId == null || newId == null) {
                 log.warn("Could not resolve commit hashes: {} -> {}", fromHash, toHash);
-                return List.of();
+                return ChangedMappings.empty();
             }
 
             AbstractTreeIterator oldTree = prepareTreeParser(repository, oldId);
@@ -320,17 +321,26 @@ private boolean isGitRepo() {
                     .call();
 
             Path repoRoot = getGitFolder().toPath();
-            return diffs.stream()
+            List<Path> upsertedFiles = diffs.stream()
                     .filter(d -> d.getChangeType() == DiffEntry.ChangeType.ADD
                             || d.getChangeType() == DiffEntry.ChangeType.MODIFY)
                     .map(DiffEntry::getNewPath)
                     .filter(path -> path.endsWith(".json"))
                     .map(repoRoot::resolve)
                     .toList();
+
+            List<String> deletedFileNames = diffs.stream()
+                    .filter(d -> d.getChangeType() == DiffEntry.ChangeType.DELETE)
+                    .map(DiffEntry::getOldPath)
+                    .filter(path -> path.endsWith(".json"))
+                    .map(path -> path.substring(path.lastIndexOf('/') + 1))
+                    .toList();
+
+            return new ChangedMappings(upsertedFiles, deletedFileNames);
         } catch (Exception e) {
             log.warn("Failed to get changed files between {} and {}", fromHash, toHash, e);
         }
-        return List.of();
+        return ChangedMappings.empty();
     }
 
     private AbstractTreeIterator prepareTreeParser(Repository repository, ObjectId objectId) throws IOException {

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataService.java
@@ -12,6 +12,7 @@ import org.cardanofoundation.tokenmetadata.registry.util.TokenMetadataValidator;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.cardanofoundation.tokenmetadata.registry.util.MappingsUtil.toTokenLogo;
 
@@ -55,6 +56,31 @@ public class TokenMetadataService {
      *
      * @return true if successfully inserted, false if validation failed or error occurred
      */
+    /**
+     * Deletes the metadata (and its logo, which has a foreign key on metadata) for a subject
+     * whose mapping file was removed from the upstream registry. Deleting a subject that is
+     * not present locally is a no-op.
+     *
+     * @return true if the deletion succeeded (including the no-op case), false if an error occurred
+     */
+    public boolean deleteMapping(String subject) {
+        try {
+            tokenLogoRepository.deleteById(subject);
+            tokenMetadataRepository.deleteById(subject);
+            return true;
+        } catch (Exception e) {
+            log.error("Failed to delete token metadata for subject '{}': {}", subject, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * @return subjects of all CIP-26 metadata rows currently stored locally
+     */
+    public List<String> findAllSubjects() {
+        return tokenMetadataRepository.findAllSubjects();
+    }
+
     public boolean insertLogo(Mapping mapping) {
         TokenLogo tokenLogo = toTokenLogo(mapping);
 

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.cardanofoundation.tokenmetadata.registry.entity.OffChainSyncState;
+import org.cardanofoundation.tokenmetadata.registry.model.ChangedMappings;
 import org.cardanofoundation.tokenmetadata.registry.model.Mapping;
 import org.cardanofoundation.tokenmetadata.registry.model.MappingUpdateDetails;
 import org.cardanofoundation.tokenmetadata.registry.model.enums.SyncStatusEnum;
@@ -75,8 +76,10 @@ public class TokenMetadataSyncService {
                 return;
             }
 
-            List<File> filesToProcess = resolveFilesToProcess(lastHash, newHashOpt, repoPathOpt.get());
-            log.info("Resolved {} file(s) to process", filesToProcess.size());
+            SyncWorkload workload = resolveWorkload(lastHash, newHashOpt, repoPathOpt.get());
+            List<File> filesToProcess = workload.filesToProcess();
+            log.info("Resolved {} file(s) to process, {} subject(s) to delete",
+                    filesToProcess.size(), workload.subjectsToDelete().size());
 
             // Batch-resolve git metadata for all files in a single history walk
             Set<String> fileNames = filesToProcess.stream()
@@ -89,6 +92,7 @@ public class TokenMetadataSyncService {
 
             long processStart = System.currentTimeMillis();
             boolean hasFailures = processMappingFiles(filesToProcess, mappingDetailsMap);
+            hasFailures |= processDeletions(workload.subjectsToDelete());
 
             if (hasFailures) {
                 log.warn("Some mappings failed to process. Commit hash will not be advanced so failed mappings are retried on next sync.");
@@ -192,19 +196,76 @@ public class TokenMetadataSyncService {
                 : fileName;
     }
 
-    private List<File> resolveFilesToProcess(String lastHash, Optional<String> newHashOpt, Path repoPath) {
+    /**
+     * Mapping files to upsert and subjects to delete for one sync run.
+     * Incremental sync derives both from the git diff between the last processed commit and HEAD.
+     * Full sync upserts every file in the mappings folder and deletes DB subjects whose file is gone.
+     */
+    private record SyncWorkload(List<File> filesToProcess, List<String> subjectsToDelete) {
+    }
+
+    private SyncWorkload resolveWorkload(String lastHash, Optional<String> newHashOpt, Path repoPath) {
         if (lastHash != null && newHashOpt.isPresent()) {
             log.info("Incremental sync from {} to {}", lastHash, newHashOpt.get());
-            List<File> files = gitService.getChangedFiles(lastHash, newHashOpt.get()).stream()
+            ChangedMappings changedMappings = gitService.getChangedMappings(lastHash, newHashOpt.get());
+            List<File> files = changedMappings.upsertedFiles().stream()
                     .map(Path::toFile).toList();
-            log.info("Incremental sync: processing {} changed file(s)", files.size());
-            return files;
+            List<String> subjectsToDelete = changedMappings.deletedFileNames().stream()
+                    .map(TokenMetadataSyncService::stripJsonExtension)
+                    .toList();
+            log.info("Incremental sync: processing {} changed file(s), {} deleted file(s)",
+                    files.size(), subjectsToDelete.size());
+            return new SyncWorkload(files, subjectsToDelete);
         }
 
         log.info("Full sync: processing all files");
         File mappings = repoPath.toFile();
-        return Optional.ofNullable(mappings.listFiles())
+        List<File> files = Optional.ofNullable(mappings.listFiles())
                 .map(Arrays::asList).orElse(List.of());
+        return new SyncWorkload(files, resolveStaleSubjects(files));
+    }
+
+    /**
+     * Full-sync reconciliation: subjects present in the local DB whose mapping file no longer
+     * exists in the registry were removed upstream (possibly while commit-hash tracking was
+     * unavailable) and must be deleted locally.
+     */
+    private List<String> resolveStaleSubjects(List<File> presentFiles) {
+        if (presentFiles.isEmpty()) {
+            log.warn("Full sync found no mapping files. Skipping stale-subject cleanup as a safety measure.");
+            return List.of();
+        }
+        Set<String> presentSubjects = new HashSet<>();
+        for (File presentFile : presentFiles) {
+            presentSubjects.add(stripJsonExtension(presentFile.getName()));
+        }
+        List<String> staleSubjects = tokenMetadataService.findAllSubjects().stream()
+                .filter(subject -> !presentSubjects.contains(subject))
+                .toList();
+        if (!staleSubjects.isEmpty()) {
+            log.info("Full sync: {} stale subject(s) no longer present in the registry will be deleted",
+                    staleSubjects.size());
+        }
+        return staleSubjects;
+    }
+
+    private boolean processDeletions(List<String> subjectsToDelete) {
+        if (subjectsToDelete.isEmpty()) {
+            return false;
+        }
+        boolean failures = false;
+        int deleted = 0;
+        for (String subject : subjectsToDelete) {
+            if (tokenMetadataService.deleteMapping(subject)) {
+                deleted++;
+                log.info("Deleted metadata for subject '{}' removed from the registry", subject);
+            } else {
+                failures = true;
+            }
+        }
+        log.info("Deletion processing complete: {}/{} deleted, failures={}",
+                deleted, subjectsToDelete.size(), failures);
+        return failures;
     }
 
 }

--- a/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
+++ b/common/src/main/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncService.java
@@ -76,10 +76,10 @@ public class TokenMetadataSyncService {
                 return;
             }
 
-            SyncWorkload workload = resolveWorkload(lastHash, newHashOpt, repoPathOpt.get());
-            List<File> filesToProcess = workload.filesToProcess();
+            PendingChanges pendingChanges = resolvePendingChanges(lastHash, newHashOpt, repoPathOpt.get());
+            List<File> filesToProcess = pendingChanges.filesToProcess();
             log.info("Resolved {} file(s) to process, {} subject(s) to delete",
-                    filesToProcess.size(), workload.subjectsToDelete().size());
+                    filesToProcess.size(), pendingChanges.subjectsToDelete().size());
 
             // Batch-resolve git metadata for all files in a single history walk
             Set<String> fileNames = filesToProcess.stream()
@@ -92,7 +92,7 @@ public class TokenMetadataSyncService {
 
             long processStart = System.currentTimeMillis();
             boolean hasFailures = processMappingFiles(filesToProcess, mappingDetailsMap);
-            hasFailures |= processDeletions(workload.subjectsToDelete());
+            hasFailures |= processDeletions(pendingChanges.subjectsToDelete());
 
             if (hasFailures) {
                 log.warn("Some mappings failed to process. Commit hash will not be advanced so failed mappings are retried on next sync.");
@@ -196,15 +196,7 @@ public class TokenMetadataSyncService {
                 : fileName;
     }
 
-    /**
-     * Mapping files to upsert and subjects to delete for one sync run.
-     * Incremental sync derives both from the git diff between the last processed commit and HEAD.
-     * Full sync upserts every file in the mappings folder and deletes DB subjects whose file is gone.
-     */
-    private record SyncWorkload(List<File> filesToProcess, List<String> subjectsToDelete) {
-    }
-
-    private SyncWorkload resolveWorkload(String lastHash, Optional<String> newHashOpt, Path repoPath) {
+    private PendingChanges resolvePendingChanges(String lastHash, Optional<String> newHashOpt, Path repoPath) {
         if (lastHash != null && newHashOpt.isPresent()) {
             log.info("Incremental sync from {} to {}", lastHash, newHashOpt.get());
             ChangedMappings changedMappings = gitService.getChangedMappings(lastHash, newHashOpt.get());
@@ -215,14 +207,14 @@ public class TokenMetadataSyncService {
                     .toList();
             log.info("Incremental sync: processing {} changed file(s), {} deleted file(s)",
                     files.size(), subjectsToDelete.size());
-            return new SyncWorkload(files, subjectsToDelete);
+            return new PendingChanges(files, subjectsToDelete);
         }
 
         log.info("Full sync: processing all files");
         File mappings = repoPath.toFile();
         List<File> files = Optional.ofNullable(mappings.listFiles())
                 .map(Arrays::asList).orElse(List.of());
-        return new SyncWorkload(files, resolveStaleSubjects(files));
+        return new PendingChanges(files, resolveStaleSubjects(files));
     }
 
     /**
@@ -266,6 +258,33 @@ public class TokenMetadataSyncService {
         log.info("Deletion processing complete: {}/{} deleted, failures={}",
                 deleted, subjectsToDelete.size(), failures);
         return failures;
+    }
+
+    /**
+     * The database changes one sync run still has to apply: mapping files to upsert and
+     * subjects to delete. How each side is resolved depends on the sync mode:
+     *
+     * <p><b>Incremental sync</b> (a last processed commit hash is stored and HEAD is known):
+     * both sides come from the git tree diff between the two commits. Added/modified mapping
+     * files become {@code filesToProcess}; deleted mapping files become {@code subjectsToDelete}
+     * (filename minus the {@code .json} extension — for canonical registry entries the filename
+     * equals the subject; for the mismatched spam files that were never indexed the resulting
+     * delete is a harmless no-op).
+     *
+     * <p><b>Full sync</b> (first run, or commit-hash tracking unavailable): there is no diff to
+     * consult, so {@code filesToProcess} is every file in the mappings folder and
+     * {@code subjectsToDelete} is derived by reconciliation — DB subjects with no corresponding
+     * mapping file were removed upstream while tracking was lost and must go. An empty mappings
+     * folder is treated as a broken clone rather than "everything was deleted", and yields no
+     * deletions.
+     *
+     * <p>Failed deletions, like failed upserts, prevent the commit hash from advancing so the
+     * work is retried on the next run.
+     *
+     * @param filesToProcess   mapping files to parse and upsert into the metadata/logo tables
+     * @param subjectsToDelete subjects whose metadata (and logo) rows must be removed locally
+     */
+    private record PendingChanges(List<File> filesToProcess, List<String> subjectsToDelete) {
     }
 
 }

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/GitServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import org.cardanofoundation.tokenmetadata.registry.model.ChangedMappings;
 import org.cardanofoundation.tokenmetadata.registry.model.MappingUpdateDetails;
 
 import java.io.File;
@@ -176,7 +177,16 @@ class GitServiceTest {
     }
 
     @Nested
-    class GetChangedFiles {
+    class GetChangedMappings {
+
+        private RevCommit deleteMappingFile(Git git, String fileName) throws Exception {
+            Path repoDir = git.getRepository().getWorkTree().toPath();
+            Files.delete(repoDir.resolve("mappings/" + fileName));
+            git.rm().addFilepattern("mappings/" + fileName).call();
+            return git.commit().setMessage("delete " + fileName)
+                    .setAuthor(new PersonIdent("Dev", "dev@test.com"))
+                    .call();
+        }
 
         @Test
         void returnsAddedJsonFilesInMappingsFolder() throws Exception {
@@ -187,10 +197,11 @@ class GitServiceTest {
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).hasSize(1);
-            assertThat(changed.get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -203,10 +214,11 @@ class GitServiceTest {
             addMappingFile(testRepo, "token1.json", "{\"v\":2}", "dev@test.com");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).hasSize(1);
-            assertThat(changed.get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -219,10 +231,10 @@ class GitServiceTest {
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).hasSize(1);
-            assertThat(changed.get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().get(0).getFileName()).hasToString("token1.json");
         }
 
         @Test
@@ -241,31 +253,79 @@ class GitServiceTest {
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).hasSize(1);
-            assertThat(changed.get(0).getFileName()).hasToString("token1.json");
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().get(0).getFileName()).hasToString("token1.json");
         }
 
         @Test
-        void filtersOutDeletedFiles() throws Exception {
+        void reportsDeletedJsonFiles() throws Exception {
             testRepo = initRepoWithMappings();
             gitService.git = testRepo;
             addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
             addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
             String fromHash = testRepo.getRepository().resolve("HEAD").name();
 
-            Path repoDir = testRepo.getRepository().getWorkTree().toPath();
-            Files.delete(repoDir.resolve("mappings/token1.json"));
-            testRepo.rm().addFilepattern("mappings/token1.json").call();
-            testRepo.commit().setMessage("delete token1")
-                    .setAuthor(new PersonIdent("Dev", "dev@test.com"))
-                    .call();
+            deleteMappingFile(testRepo, "token1.json");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).isEmpty();
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).containsExactly("token1.json");
+        }
+
+        @Test
+        void filtersOutDeletedNonJsonFiles() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "readme.txt", "text", "dev@test.com");
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "readme.txt");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
+
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
+        }
+
+        @Test
+        void reportsDeletionsAlongsideUpserts() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "token1.json", "{}", "dev@test.com");
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "token1.json");
+            addMappingFile(testRepo, "token2.json", "{}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
+
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.upsertedFiles().get(0).getFileName()).hasToString("token2.json");
+            assertThat(changed.deletedFileNames()).containsExactly("token1.json");
+        }
+
+        @Test
+        void doesNotReportDeletionWhenFileIsDeletedAndReAddedWithinRange() throws Exception {
+            testRepo = initRepoWithMappings();
+            gitService.git = testRepo;
+            addMappingFile(testRepo, "token1.json", "{\"v\":1}", "dev@test.com");
+            String fromHash = testRepo.getRepository().resolve("HEAD").name();
+
+            deleteMappingFile(testRepo, "token1.json");
+            addMappingFile(testRepo, "token1.json", "{\"v\":2}", "dev@test.com");
+            String toHash = testRepo.getRepository().resolve("HEAD").name();
+
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
+
+            // The tree diff sees the net change (a modification), not the intermediate delete.
+            assertThat(changed.upsertedFiles()).hasSize(1);
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -274,9 +334,10 @@ class GitServiceTest {
             gitService.git = testRepo;
             String hash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(hash, hash);
+            ChangedMappings changed = gitService.getChangedMappings(hash, hash);
 
-            assertThat(changed).isEmpty();
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -284,11 +345,12 @@ class GitServiceTest {
             testRepo = initRepoWithMappings();
             gitService.git = testRepo;
 
-            List<Path> changed = gitService.getChangedFiles(
+            ChangedMappings changed = gitService.getChangedMappings(
                     "0000000000000000000000000000000000000000",
                     "1111111111111111111111111111111111111111");
 
-            assertThat(changed).isEmpty();
+            assertThat(changed.upsertedFiles()).isEmpty();
+            assertThat(changed.deletedFileNames()).isEmpty();
         }
 
         @Test
@@ -302,9 +364,9 @@ class GitServiceTest {
             addMappingFile(testRepo, "token3.json", "{}", "dev@test.com");
             String toHash = testRepo.getRepository().resolve("HEAD").name();
 
-            List<Path> changed = gitService.getChangedFiles(fromHash, toHash);
+            ChangedMappings changed = gitService.getChangedMappings(fromHash, toHash);
 
-            assertThat(changed).hasSize(3)
+            assertThat(changed.upsertedFiles()).hasSize(3)
                     .extracting(p -> p.getFileName().toString())
                     .containsExactlyInAnyOrder("token1.json", "token2.json", "token3.json");
         }

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataServiceTest.java
@@ -126,6 +126,29 @@ class TokenMetadataServiceTest {
     }
 
     @Test
+    void deleteMappingTest_ShouldDeleteLogoBeforeMetadata() {
+        String subject = "ff7cad970d3a755a1ff0335ccb3f3c1cabf31aacf3f23dd13db61b0630313030";
+
+        boolean result = tokenMetadataService.deleteMapping(subject);
+
+        Assertions.assertTrue(result, "deleteMapping should return true when deletes succeed");
+        // The logo table has a foreign key on metadata.subject, so the logo row must go first.
+        org.mockito.InOrder inOrder = Mockito.inOrder(tokenLogoRepository, tokenMetadataRepository);
+        inOrder.verify(tokenLogoRepository).deleteById(subject);
+        inOrder.verify(tokenMetadataRepository).deleteById(subject);
+    }
+
+    @Test
+    void deleteMappingTest_ShouldReturnFalseOnDeleteException() {
+        String subject = "ff7cad970d3a755a1ff0335ccb3f3c1cabf31aacf3f23dd13db61b0630313030";
+        Mockito.doThrow(new RuntimeException("DB error")).when(tokenMetadataRepository).deleteById(subject);
+
+        boolean result = tokenMetadataService.deleteMapping(subject);
+
+        Assertions.assertFalse(result, "deleteMapping should return false when delete throws");
+    }
+
+    @Test
     void insertMappingTest_ShouldRejectTokenWithNameExceedingMaxLength() {
         LocalDateTime now = LocalDateTime.now();
         String testUser = "test-user";

--- a/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncServiceTest.java
+++ b/common/src/test/java/org/cardanofoundation/tokenmetadata/registry/service/TokenMetadataSyncServiceTest.java
@@ -1,6 +1,7 @@
 package org.cardanofoundation.tokenmetadata.registry.service;
 
 import org.cardanofoundation.tokenmetadata.registry.entity.OffChainSyncState;
+import org.cardanofoundation.tokenmetadata.registry.model.ChangedMappings;
 import org.cardanofoundation.tokenmetadata.registry.model.Mapping;
 import org.cardanofoundation.tokenmetadata.registry.model.MappingUpdateDetails;
 import org.cardanofoundation.tokenmetadata.registry.model.enums.SyncStatusEnum;
@@ -82,7 +83,8 @@ class TokenMetadataSyncServiceTest {
             when(mockFile.getName()).thenReturn("test.json");
             Path mockFilePath = mock(Path.class);
             when(mockFilePath.toFile()).thenReturn(mockFile);
-            when(gitService.getChangedFiles(oldHash, newHash)).thenReturn(List.of(mockFilePath));
+            when(gitService.getChangedMappings(oldHash, newHash))
+                    .thenReturn(new ChangedMappings(List.of(mockFilePath), List.of()));
 
             Mapping mockMapping = new Mapping("test", null, null, null, null, null, null, null);
             when(tokenMappingService.parseMappings(mockFile)).thenReturn(Optional.of(mockMapping));
@@ -93,6 +95,7 @@ class TokenMetadataSyncServiceTest {
             tokenMetadataSyncService.synchronizeDatabase();
 
             verify(tokenMetadataService).insertMapping(any(), any(), any());
+            verify(tokenMetadataService, never()).deleteMapping(any());
             verify(syncStateRepository).save(any(OffChainSyncState.class));
             assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
         }
@@ -149,7 +152,8 @@ class TokenMetadataSyncServiceTest {
             when(mockFile.getName()).thenReturn("test.json");
             Path mockFilePath = mock(Path.class);
             when(mockFilePath.toFile()).thenReturn(mockFile);
-            when(gitService.getChangedFiles(oldHash, newHash)).thenReturn(List.of(mockFilePath));
+            when(gitService.getChangedMappings(oldHash, newHash))
+                    .thenReturn(new ChangedMappings(List.of(mockFilePath), List.of()));
 
             Mapping mockMapping = new Mapping("test", null, null, null, null, null, null, null);
             when(tokenMappingService.parseMappings(mockFile)).thenReturn(Optional.of(mockMapping));
@@ -195,7 +199,8 @@ class TokenMetadataSyncServiceTest {
             Path garbagePath = mock(Path.class);
             when(garbagePath.toFile()).thenReturn(garbageFile);
 
-            when(gitService.getChangedFiles(oldHash, newHash)).thenReturn(List.of(legitPath, garbagePath));
+            when(gitService.getChangedMappings(oldHash, newHash))
+                    .thenReturn(new ChangedMappings(List.of(legitPath, garbagePath), List.of()));
             when(gitService.getAllMappingDetails(any())).thenReturn(Map.of(
                     "legit.json", new MappingUpdateDetails("author", LocalDateTime.now()),
                     "garbage.json", new MappingUpdateDetails("author", LocalDateTime.now())));
@@ -210,6 +215,94 @@ class TokenMetadataSyncServiceTest {
             // Only one insert: from legit.json. garbage.json is filtered before reaching insertMapping.
             verify(tokenMetadataService, times(1)).insertMapping(any(), any(), any());
             verify(syncStateRepository).save(any(OffChainSyncState.class));
+            assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
+        }
+    }
+
+    @Nested
+    class TokenRemovals {
+
+        @Test
+        void incrementalSync_deletesTokensRemovedFromRegistry() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.of(new OffChainSyncState(oldHash)));
+            Path mockRepoPath = mock(Path.class);
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.of(mockRepoPath));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(newHash));
+
+            when(gitService.getChangedMappings(oldHash, newHash))
+                    .thenReturn(new ChangedMappings(List.of(), List.of("removedtoken.json")));
+            when(tokenMetadataService.deleteMapping("removedtoken")).thenReturn(true);
+
+            tokenMetadataSyncService.synchronizeDatabase();
+
+            verify(tokenMetadataService).deleteMapping("removedtoken");
+            verify(tokenMetadataService, never()).insertMapping(any(), any(), any());
+            verify(syncStateRepository).save(any(OffChainSyncState.class));
+            assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
+        }
+
+        @Test
+        void hashNotAdvanced_whenDeleteFails() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.of(new OffChainSyncState(oldHash)));
+            Path mockRepoPath = mock(Path.class);
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.of(mockRepoPath));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(newHash));
+
+            when(gitService.getChangedMappings(oldHash, newHash))
+                    .thenReturn(new ChangedMappings(List.of(), List.of("removedtoken.json")));
+            when(tokenMetadataService.deleteMapping("removedtoken")).thenReturn(false);
+
+            tokenMetadataSyncService.synchronizeDatabase();
+
+            // Failed deletion must be retried on the next sync, so the commit hash is not advanced.
+            verify(syncStateRepository, never()).save(any());
+            assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
+        }
+
+        @Test
+        void fullSync_deletesStaleSubjectsNoLongerInRegistry() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            Path mockRepoPath = mock(Path.class);
+            File mockMappingsDir = mock(File.class);
+            when(mockRepoPath.toFile()).thenReturn(mockMappingsDir);
+            File presentFile = mock(File.class);
+            when(presentFile.getName()).thenReturn("presenttoken.json");
+            when(mockMappingsDir.listFiles()).thenReturn(new File[] {presentFile});
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.of(mockRepoPath));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(newHash));
+
+            when(tokenMappingService.parseMappings(presentFile))
+                    .thenReturn(Optional.of(new Mapping("presenttoken", null, null, null, null, null, null, null)));
+            when(gitService.getAllMappingDetails(any()))
+                    .thenReturn(Map.of("presenttoken.json", new MappingUpdateDetails("author", LocalDateTime.now())));
+            when(tokenMetadataService.insertMapping(any(), any(), any())).thenReturn(true);
+            when(tokenMetadataService.findAllSubjects()).thenReturn(List.of("presenttoken", "staletoken"));
+            when(tokenMetadataService.deleteMapping("staletoken")).thenReturn(true);
+
+            tokenMetadataSyncService.synchronizeDatabase();
+
+            verify(tokenMetadataService).deleteMapping("staletoken");
+            verify(tokenMetadataService, never()).deleteMapping("presenttoken");
+            verify(syncStateRepository).save(any(OffChainSyncState.class));
+            assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
+        }
+
+        @Test
+        void fullSync_skipsStaleCleanup_whenNoMappingFilesFound() {
+            when(syncStateRepository.findTopByOrderByIdDesc()).thenReturn(Optional.empty());
+            Path mockRepoPath = mock(Path.class);
+            File mockMappingsDir = mock(File.class);
+            when(mockRepoPath.toFile()).thenReturn(mockMappingsDir);
+            when(mockMappingsDir.listFiles()).thenReturn(new File[] {});
+            when(gitService.cloneCardanoTokenRegistryGitRepository()).thenReturn(Optional.of(mockRepoPath));
+            when(gitService.getHeadCommitHash()).thenReturn(Optional.of(newHash));
+
+            tokenMetadataSyncService.synchronizeDatabase();
+
+            // An empty mappings folder is treated as a broken clone, not a registry
+            // where every token was removed — nothing must be deleted.
+            verify(tokenMetadataService, never()).findAllSubjects();
+            verify(tokenMetadataService, never()).deleteMapping(any());
             assertEquals(SyncStatusEnum.SYNC_DONE, tokenMetadataSyncService.getSyncStatus().getStatus());
         }
     }

--- a/regression-tests/mainnet/fixtures/cip26_removed_tokens.json
+++ b/regression-tests/mainnet/fixtures/cip26_removed_tokens.json
@@ -1,0 +1,362 @@
+[
+  {
+    "subject": "007394e3117755fbb0558b93c54ce3bc6c85770920044ade143dc7424506f636b65744368616e6765",
+    "name": "Pocket Change",
+    "deleted_commit": "2c17d0672550b8b0b18ff19c6f9af3e5011a3668",
+    "deleted_at": "2022-12-12T12:03:24+01:00"
+  },
+  {
+    "subject": "160a880d9fc45380737cb7e57ff859763230aab28b3ef6a84007bfcc4d49524",
+    "name": "VOID",
+    "deleted_commit": "81459cacb37427c59e20ae893747bc5f02651a15",
+    "deleted_at": "2022-09-29T14:01:25+02:00"
+  },
+  {
+    "subject": "1b12639e4d78aedd982cfd489900b2e7628c8d0afc20ddcaec7b1cf04c494649",
+    "name": "Linkage Finance",
+    "deleted_commit": "8325a77725fb18d6daf67d2cd18d0ff5c7520e97",
+    "deleted_at": "2023-08-02T11:17:00+02:00"
+  },
+  {
+    "subject": "1d7f33bd23d85e1a25d87d86fac4f199c3197a2f7afeb662a0f34e1e576f726c64204d6f62696c6520546f6b656e",
+    "name": "VOID",
+    "deleted_commit": "85d23579125d4320fec3baf393775f37d0e72995",
+    "deleted_at": "2021-07-09T02:01:28-07:00"
+  },
+  {
+    "subject": "227fe9345cb9ef390d1acf14dba24b6522ad8a5788c5224555f58bd95452555354",
+    "name": "TRUST Pool",
+    "deleted_commit": "4660dfb71593b94a1c2c05f8f3564940cf1d51f0",
+    "deleted_at": "2022-01-28T21:39:51-08:00"
+  },
+  {
+    "subject": "230ad52f87dde3e38dcf01521dc5c0e62f611cb528917fef2fe6ef8d4d6574617370616365706164",
+    "name": "VOID",
+    "deleted_commit": "8306a9bc84bfd5d8840cf6072f8f45163bf9fedb",
+    "deleted_at": "2024-09-06T12:12:11-03:00"
+  },
+  {
+    "subject": "244f52eae7aa628c21285c4666b02d05d541057f9ed583ce315fce4542414e4b",
+    "name": "Bankercoin",
+    "deleted_commit": "26bb32f57002db75228f5127a4f34ffad069be41",
+    "deleted_at": "2023-06-05T12:13:25+02:00"
+  },
+  {
+    "subject": "28193a95061f7f7a64877b6cb8ffea32b30cdb1a73780bfee914032c0014df1052656c61784149",
+    "name": "VOID",
+    "deleted_commit": "1e368505400e735042bdd9b5b8201cf8196b1485",
+    "deleted_at": "2024-09-06T12:45:42-03:00"
+  },
+  {
+    "subject": "2d8cee2c3c82664023da28372e46995daab7111070abf5fc9aee72ea6672414441",
+    "name": "ADAFR Pool Reward ADA",
+    "deleted_commit": "875a4b5c954374cdca6b656e8b116dd47562ccc7",
+    "deleted_at": "2026-08-13T12:18:21+02:00"
+  },
+  {
+    "subject": "36088d63cf12e1e23d163c8be5c7fcfa2871623dc650c915e89c6f03",
+    "name": "Liqwid ETH Liquidation",
+    "deleted_commit": "458ee6d7ad054c9e3062f09ec92c80cc1550f9e6",
+    "deleted_at": "2025-05-15T13:26:14+01:00"
+  },
+  {
+    "subject": "3b933dac8e862b1ed3f4a1c319165f34dd7b1e7a47826b67a10883e54347454d",
+    "name": "VOID",
+    "deleted_commit": "fcbce18eab45b7be59ef66df9b6e5a2a2ad40288",
+    "deleted_at": "2023-05-17T12:15:57+02:00"
+  },
+  {
+    "subject": "3d3170d07cd2ddfd9be6fc24c36309c1a4ccdf43c3520d0395ceb5f3444f52454d4f4e",
+    "name": "DOREMON",
+    "deleted_commit": "56296098f8de593c034eec0ba4cfa1dfd31ebb42",
+    "deleted_at": "2024-04-01T15:50:21+07:00"
+  },
+  {
+    "subject": "3f0adaa27a6626c5f5d4e0128a7050cbc34effbad68fabc6369dfb31",
+    "name": "Liqwid LQ Borrow",
+    "deleted_commit": "458ee6d7ad054c9e3062f09ec92c80cc1550f9e6",
+    "deleted_at": "2025-05-15T13:26:14+01:00"
+  },
+  {
+    "subject": "42021555abb9323dfc9d7fb022203f90b4f857f7725722fa2c7e126843686f73656e20436f696e",
+    "name": "VOID",
+    "deleted_commit": "7877b8a66bba77a38e46ab8dfcb6f9ed35f4e295",
+    "deleted_at": "2023-02-25T09:59:35+01:00"
+  },
+  {
+    "subject": "43037651dfa0a5b01235828ead1f42ff74db2ae6cc9b6d96d1dc34654c5158",
+    "name": "LiqwidUSD Governance Token",
+    "deleted_commit": "1ee9e1e459c8faa96353f82a952af809e661b796",
+    "deleted_at": "2022-02-12T22:06:08+01:00"
+  },
+  {
+    "subject": "4343662b13b2e9bd01deb6df527dc49ceeca6cb4d9909ec3dfa27b004655434b53414d",
+    "name": "FUCK SAM BANKMAN FRIED",
+    "deleted_commit": "6a95d69ecdc7e9e72d5abed6504344e282928b88",
+    "deleted_at": "2023-05-04T07:09:50-06:00"
+  },
+  {
+    "subject": "43b07d4037f0d75ee10f9863097463fc02ff3c0b8b705ae61d9c75bf",
+    "name": "VOID",
+    "deleted_commit": "5836081f8627891a655cbeb66aca0c837705a17d",
+    "deleted_at": "2023-05-03T15:43:48+02:00"
+  },
+  {
+    "subject": "4c5d3e85af1072e82a7d9b3fdad1532312e937b955f19c3b8c2475b9",
+    "name": "Liqwid iUSD Action",
+    "deleted_commit": "30feb1cf1baeef0cc196e36c45c3edc4c5492f6f",
+    "deleted_at": "2023-05-30T15:40:11+02:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8447261676f6e61757261303031",
+    "name": "Dragon aura rarity 1/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8447261676f6e61757261303032",
+    "name": "Dragon aura rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8447261676f6e61757261303033",
+    "name": "Dragon aura rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8447261676f6e61757261303034",
+    "name": "Dragon aura rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8447261676f6e61757261303035",
+    "name": "Dragon aura rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361312f3130",
+    "name": "Flying Francesca #116 rarity 1/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e636573636131302f3130",
+    "name": "Flying Francesca #116 rarity 10/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361322f3130",
+    "name": "Flying Francesca #116 rarity 2/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361332f3130",
+    "name": "Flying Francesca #116 rarity 3/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361342f3130",
+    "name": "Flying Francesca #116 rarity 4/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361352f3130",
+    "name": "Flying Francesca #116 rarity 5/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361362f3130",
+    "name": "Flying Francesca #116 rarity 6/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361372f3130",
+    "name": "Flying Francesca #116 rarity 7/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361382f3130",
+    "name": "Flying Francesca #116 rarity 8/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8466c79696e674672616e6365736361392f3130",
+    "name": "Flying Francesca #116 rarity 9/10",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84672616e63657363614e6f63657261303031",
+    "name": "Francesca Nocera rarity 1/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84672616e63657363614e6f63657261303032",
+    "name": "Francesca Nocera rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84672616e63657363614e6f63657261303033",
+    "name": "Francesca Nocera rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84672616e63657363614e6f63657261303034",
+    "name": "Francesca Nocera rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84672616e63657363614e6f63657261303035",
+    "name": "Francesca Nocera rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8476f6c64656e6272696465303031",
+    "name": "Golden bride rarity 1/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8476f6c64656e6272696465303032",
+    "name": "Golden bride rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8476f6c64656e6272696465303033",
+    "name": "Golden bride rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8476f6c64656e6272696465303034",
+    "name": "Golden bride rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8476f6c64656e6272696465303035",
+    "name": "Golden bride rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8477265656e676f7369303032",
+    "name": "Greengosi rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8477265656e676f7369303033",
+    "name": "Greengosi rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8477265656e676f7369303034",
+    "name": "Greengosi rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8477265656e676f7369303035",
+    "name": "Greengosi rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84d6574726f706f6c6974616e6f303031",
+    "name": "VOID",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84d6574726f706f6c6974616e6f303032",
+    "name": "Metropolitano rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84d6574726f706f6c6974616e6f303033",
+    "name": "Metropolitano rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84d6574726f706f6c6974616e6f303034",
+    "name": "Metropolitano rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c84d6574726f706f6c6974616e6f303035",
+    "name": "Metropolitano rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8506561636566756c7361696c696e67303031",
+    "name": "Peaceful sailing rarity 1/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8506561636566756c7361696c696e67303032",
+    "name": "Peaceful sailing rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8506561636566756c7361696c696e67303033",
+    "name": "Peaceful sailing rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8506561636566756c7361696c696e67303034",
+    "name": "Peaceful sailing rarity 4/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8506561636566756c7361696c696e67303035",
+    "name": "Peaceful sailing rarity 5/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8536361726564303031",
+    "name": "Scared rarity 1/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8536361726564303032",
+    "name": "Scared rarity 2/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  },
+  {
+    "subject": "585f042622bebacfe75f6b0d64d4ca2020c1d3ae2645b2d28a8ba7c8536361726564303033",
+    "name": "Scared rarity 3/5",
+    "deleted_commit": "a2331215063464909c2918faa4f8325d67994712",
+    "deleted_at": "2022-02-06T13:05:06+01:00"
+  }
+]

--- a/regression-tests/mainnet/pytest.ini
+++ b/regression-tests/mainnet/pytest.ini
@@ -7,3 +7,4 @@ markers =
     v2: V2 API endpoint tests
     batch: Batch query tests
     sanity: Sanity / smoke tests
+    deletion: Tests asserting upstream registry deletions are propagated (issue #97)

--- a/regression-tests/mainnet/test_v1_removed_subjects.py
+++ b/regression-tests/mainnet/test_v1_removed_subjects.py
@@ -1,0 +1,63 @@
+"""
+V1 API: deleted registry entries must not be served (issue #97).
+
+Guards the invariant that a CIP-26 token whose mapping file was removed from the
+upstream cardano-token-registry is no longer served by the API.
+
+The fixture `cip26_removed_tokens.json` was mined from the upstream repository's
+git history: every entry was once a canonical mapping (filename == inner subject,
+valid name + description, so the sync WOULD have indexed it) whose file was later
+deleted and is still absent at HEAD. It includes the exact token from issue #97
+(subject 2d8cee2c...6672414441, "ADAFR Pool Reward ADA", removed upstream in
+cardano-token-registry PR #8014).
+
+This fixture is a frozen baseline like the others — do not regenerate during a
+test run. If one of these tokens is ever legitimately re-added upstream, remove
+that single entry deliberately.
+
+Only V1 endpoints are asserted: V1 is the pure CIP-26 view. V2 may legitimately
+serve some of these subjects from on-chain CIP-68 data (e.g. subjects carrying
+the 0014df10 fungible-token prefix), so a V2 404 assertion would be flaky by design.
+"""
+
+import allure
+import pytest
+import requests
+
+from .conftest import _load_json, API_BASE_URL
+
+REMOVED_TOKENS = _load_json("cip26_removed_tokens.json")
+REMOVED_SUBJECTS = [t["subject"] for t in REMOVED_TOKENS]
+
+
+@allure.epic("V1 API")
+@allure.feature("Removed registry entries")
+@pytest.mark.v1
+@pytest.mark.cip26
+@pytest.mark.deletion
+class TestV1RemovedSubjects:
+
+    @allure.story("Subject deleted from the upstream registry returns 204")
+    @pytest.mark.parametrize("subject", REMOVED_SUBJECTS, ids=lambda s: s[:16])
+    def test_removed_subject_returns_204(self, subject):
+        resp = requests.get(f"{API_BASE_URL}/metadata/{subject}")
+        assert resp.status_code == 204, (
+            f"Subject {subject[:24]}... was deleted from the upstream registry "
+            f"but the API still serves it (HTTP {resp.status_code}). "
+            f"See issue #97 — deletions must be propagated to the local DB."
+        )
+
+    @allure.story("Batch query does not return subjects deleted upstream")
+    def test_batch_query_excludes_removed_subjects(self):
+        resp = requests.post(
+            f"{API_BASE_URL}/metadata/query",
+            json={"subjects": REMOVED_SUBJECTS},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        returned = {s["subject"] for s in data.get("subjects", [])}
+        leaked = returned & set(REMOVED_SUBJECTS)
+        assert not leaked, (
+            f"{len(leaked)} deleted subject(s) still returned by batch query, "
+            f"e.g. {sorted(leaked)[0][:24]}..."
+        )


### PR DESCRIPTION
Fixes #97

## Problem

When a token's mapping file is removed from the upstream [cardano-token-registry](https://github.com/cardano-foundation/cardano-token-registry), the local database never learns about it — the API keeps serving the deleted token forever. Reported today in #97 with subject `2d8cee2c...6672414441` ("frADA"), removed upstream in cardano-foundation/cardano-token-registry#8014 yet still served by `tokens.cardano.org`.

The sync only handled additions and updates, in two independent ways:

1. **Incremental sync** — `GitService.getChangedFiles` filtered the git diff to `ADD`/`MODIFY` entries only, silently dropping `DELETE` entries.
2. **Full sync** — upserted every file present in the mappings folder but never reconciled the DB against it, so rows for deleted files survived there too.

Only CIP-26 is affected; CIP-68 (on-chain) is untouched by this change.

## Fix

- `GitService.getChangedMappings` (renamed from `getChangedFiles`) returns a new `ChangedMappings` record carrying deleted mapping file names alongside upserted files.
- **Incremental sync** deletes the subjects of removed `.json` files. A failed deletion keeps the commit hash unadvanced, so it is retried on the next sync — same contract as failed inserts.
- **Full sync** reconciles: DB subjects with no corresponding file in the mappings folder are deleted (covers deletions that happened while commit-hash tracking was lost). Safety guard: an empty mappings folder is treated as a broken clone and skips cleanup instead of wiping the table.
- `TokenMetadataService.deleteMapping` deletes the `logo` row before the `metadata` row (FK ordering); deleting an absent subject is a no-op.
- A delete-then-re-add within one sync range correctly nets out to a modify (tree diff), not a deletion.

## Tests

- **Unit** (all green, full `mvn clean install` passes):
  - `GitServiceTest$GetChangedMappings` — deletion reporting, non-JSON filtering, delete+re-add netting, mixed delete/upsert ranges (11 tests)
  - `TokenMetadataSyncServiceTest$TokenRemovals` — incremental deletion, hash-not-advanced-on-failure, full-sync stale cleanup, empty-folder guard (4 tests)
  - `TokenMetadataServiceTest` — FK-safe delete ordering, error handling (2 tests)
- **Regression** (`regression-tests/mainnet`): new frozen fixture `cip26_removed_tokens.json` with 60 subjects mined from upstream git history — each was a canonical, indexable mapping (filename == inner subject, valid name+description) later deleted and still absent at HEAD. Includes the exact #97 token. `test_v1_removed_subjects.py` asserts V1 returns 204 for each and batch queries exclude them. V2 is deliberately not asserted: some removed CIP-26 subjects may legitimately resolve via on-chain CIP-68 data.
  - Verified the existing 1000-token CIP-26 baseline has **zero overlap** with upstream-deleted subjects, so this fix does not break the current suite.

## Deployment note

Long-running deployments already contain stale rows from past upstream deletions (`2d8cee2c...` among them, deleted upstream 2026-08-13). The incremental path only handles deletions from now on — purging historical leftovers requires one full-sync reconciliation, i.e. clearing the stored commit hash (or wiping the sync state) so the next run walks the whole mappings folder.